### PR TITLE
Do not wrap text in tables

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ theme:
     logo: logo.png
 extra_css:
     - wave/wave.css
+    - stylesheets/extra.css
 extra_javascript:
     - https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML
 markdown_extensions:

--- a/stylesheets/extra.css
+++ b/stylesheets/extra.css
@@ -1,0 +1,4 @@
+.wy-table-responsive table td,
+.wy-table-responsive table th {
+    white-space: normal !important;
+}


### PR DESCRIPTION
The default CSS (theme.css) disables text wrapping in tables:
```css
.wy-table-responsive table td,.wy-table-responsive table th {
    white-space:nowrap;
}
```

Override it in a custom CSS.

Before:
<img width="763" height="339" alt="image" src="https://github.com/user-attachments/assets/ded5c102-3657-48f7-9061-aa9db7e9567a" />

After:
<img width="760" height="513" alt="image" src="https://github.com/user-attachments/assets/f610ac54-95df-4b9d-bd4c-2ea0132e6073" />
