### PR TITLE
Enable push in publish GH action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,8 @@ jobs:
 
       - name: Configure git user
         run: |
+          set -eux
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 


### PR DESCRIPTION
Provide git user name and email needed for mike deploy --push. Additionally, set the fetch depth to 0.
Successful GH action run: https://github.com/Volue-Public/energy-smp-docs/actions/runs/18529510037/job/52808308309