### PR TITLE
chore: add Mesh server - Mesh Python SDK compatibility matrix

### DIFF
--- a/docs/mesh/installation/MeshServiceInstallationGuide.md
+++ b/docs/mesh/installation/MeshServiceInstallationGuide.md
@@ -718,7 +718,7 @@ This ensures that sensitive data, including credentials and queries, is protecte
 **Legend:**
 
 - ✔️ Supported - compatible
-- ❌ Not supported - incompatible, using these combination may lead to runtime errors
+- ❌ Not supported - incompatible, using these combinations may lead to runtime errors
 
 Please also refer to Mesh Python SDK [versions page](https://volue-public.github.io/energy-mesh-python/versions.html).
 


### PR DESCRIPTION
Add Mesh server - Mesh Python SDK compatibility matrix.
Include versions from 2025.