### PR TITLE
fix: remove references to non-existing Mesh system guide

### DIFF
--- a/docs/mesh/calculations/functions/introduction.md
+++ b/docs/mesh/calculations/functions/introduction.md
@@ -2,8 +2,6 @@
 
 Mesh allows you to efficiently manage time series data used in several work processes. The solution lets you structure your data in your own logical hierarchy. The hierarchy is built from custom defined object types related to each other in an object model. Time series and property types are connected to the objects.
 
-For more details about object model concepts, see Mesh System Guide.
-
 ## Template calculations setup
 
 The object model is well suited for setting up time series calculations as template expressions. This means more efficient set up and maintenance and ensures consistent results thought out the system.


### PR DESCRIPTION
Resolves #56. I've searched in the repo for "guide". It seems it was the only place with "Mesh System Guide".