### PR TITLE
chore: add link to calc functions introduction

### DIFF
--- a/docs/mesh/calculations/general.md
+++ b/docs/mesh/calculations/general.md
@@ -61,7 +61,7 @@ the world from this instance. Navigating to_PriceArea in this case ends up in
 the PriceArea instance named NO3.
 
 
-## Functions
+## Calculation functions
 
 Here are some general comments to functions used in expressions:
 
@@ -94,6 +94,8 @@ the Production series may have values every 15 minutes and the Price series may
 have values every hour.
 
 The argument to a function can be the result of another function.
+
+For more information about Mesh calculation functions, see [Calculations in Mesh - introduction](./functions/introduction.md).
 
 
 ## Calculation expression definition

--- a/docs/mesh/concepts/calculations.md
+++ b/docs/mesh/concepts/calculations.md
@@ -1,3 +1,3 @@
 # Mesh calculations
 
-For information about our Mesh calculations, see [Calculations in Mesh - general concepts](../calculations/general.md).
+For information about Mesh calculations, see [Calculations in Mesh - general concepts](../calculations/general.md).


### PR DESCRIPTION
* add link to calculation functions introduction in general page.
* rename `Functions` paragraph in general page to `Calculation functions`