### PR TITLE
fix: Mesh config param name

### DIFF
--- a/docs/mesh/installation/MeshServiceInstallationGuide.md
+++ b/docs/mesh/installation/MeshServiceInstallationGuide.md
@@ -735,7 +735,7 @@ Below is the complete `mesh.json` listed with all options with default values.
 
 ```json
 {
-  "FailOnSyncErrors": false,
+  "FailOnSynchErrors": false,  // Specifies whether Mesh should shutdown after 3 repeatable synchronization errors
   "SerializationVersion": 25,
   "ComputerName": "localhost",
   "Log": {

--- a/docs/mesh/installation/MeshServiceInstallationGuide.md
+++ b/docs/mesh/installation/MeshServiceInstallationGuide.md
@@ -735,7 +735,7 @@ Below is the complete `mesh.json` listed with all options with default values.
 
 ```json
 {
-  "FailOnSynchErrors": false,  // Specifies whether Mesh should shutdown after 3 repeatable synchronization errors
+  "FailOnSynchErrors": false,  // Specifies whether Mesh should shut down after 3 repeatable synchronisation errors
   "SerializationVersion": 25,
   "ComputerName": "localhost",
   "Log": {


### PR DESCRIPTION
Fix name of `FailOnSynchErrors` and add bare-minimum comment.