### PR TITLE
Update TRANSFORM docs

### DIFF
--- a/docs/mesh/calculations/functions/transform.md
+++ b/docs/mesh/calculations/functions/transform.md
@@ -44,9 +44,9 @@ table, as does the `@TRANSFORM(t, t, s)` function.
 
 | Symbol | Description |
 | ------ | - |
-| SUM    | The sum of the values included in the base for this value.<br/><br/>Does not consider how long the values are valid, i.e. a break point series with two values in the current interval that will give the sum of these two values. |
-| SUMI   | Integral based sum with resolution second. Calculates the sum of value multiplied with number of seconds each value is valid.<br/><br/>Value equal 1 at the start of the day will give 86400 as day value if the base is one break point series and 3600 if this is an hour series with only one value on first hour. |
-| AVG    | For fixed interval series. Sum of all values in accumulation period divided by number of values in the accumulation period (24 for hour series that is transformed to day series).<br/><br/>For break point series: Mean value of the values included in the base for this value. Does not consider how long the values are valid, i.e. a break point series with two values in the current interval that will give the mean value of these two values. |
+| SUM    | The sum of the values included in the base for this value.<br/><br/>Does not consider how long the values are valid, i.e. a breakpoint series with two values in the current interval that will give the sum of these two values. |
+| SUMI   | Integral based sum with resolution second. Calculates the sum of value multiplied with number of seconds each value is valid.<br/><br/>Value equal 1 at the start of the day will give 86400 as day value if the base is one breakpoint series and 3600 if this is an hour series with only one value on first hour. |
+| AVG    | For fixed interval series. Sum of all values in accumulation period divided by number of values in the accumulation period (24 for hour series that is transformed to day series).<br/><br/>For breakpoint series: Mean value of the values included in the base for this value. Does not consider how long the values are valid, i.e. a breakpoint series with two values in the current interval will give the mean value of these two values. |
 | AVGI   | Integral based mean value, i.e. considers how much of the accumulation period that a given value is valid (to next value that can be NaN for a fixed interval series). This value is presented as mean value in the summary part of the presentation in Table. |
 | FIRST  | First value in the accumulation period. This is the functional value at the start of the accumulation period, unless there exists an explicit value. |
 | LAST   | Last value in the accumulation period. This is the functional value at the end of the accumulation period, unless there exists an explicit value. |
@@ -67,10 +67,10 @@ the implementation chooses `SUM` if the method string contains (case insensitive
 a future version, preceded by tooling to identify erroneous cases. We strongly
 recommend using `SUM` or `AVG` instead of for example `SUMV` or `AVERAGE`.
 
-If the input time series is time zone aware we only allow `SUM` or `AVG`.
+If the input time series is time zone aware, we only allow `SUM` or `AVG`.
 
 
-## `TRANSFORM(t, s, s)`
+## TRANSFORM(t, s, s)
 
 This is the most common conversion function. You can use it to convert both
 ways, i.e. both from finer to coarser resolution, and the other way. The most
@@ -129,7 +129,7 @@ transformation methods are available for this latter use.
   ![](assets/images/ex_TRANSFORM-nimbustable7.png)
 
 
-## `TRANSFORM(t, t, s)`
+## TRANSFORM(t, t, s)
 
 Conversion to periods given by points of time on the series given as argument 2.
 The result is a break point series. This function enables periods that are not
@@ -156,7 +156,7 @@ this:
   Res is a result series with break point resolution.
 
 
-## `TRANSFORM(t, d, s)`
+## TRANSFORM(t, d, s)
 
 Conversions given by the number given as argument 2. The number represents
 number of seconds in the period.
@@ -172,7 +172,7 @@ number of seconds in the period.
 If d is defined as the value 864000 this means a period of 10 days
 (60*60*24*10). The result is a break point series.
 
-## `TRANSFORM(t, s, s, s)`
+## TRANSFORM(t, s, s, s)
 
 Corresponding functionality as in [`TRANSFORM(t, s, s)`](#transformt-s-s), but
 with an additional argument that decides which time zone that is the base for

--- a/docs/mesh/calculations/functions/transform.md
+++ b/docs/mesh/calculations/functions/transform.md
@@ -1,9 +1,13 @@
-## TRANSFORM
-This topic describes the TRANSFORM variants ([R1](#r1), [R2](#r2), [R3](#r3),
-[R4](#r4)) for transforming from one time resolution to another. To
-get an overview of all the transformation function variants, see:
+# TRANSFORM
 
-[Which functions can be used when?](../functions/transform_what_when.md)
+This topic describes the [`TRANSFORM(t, s, s)`](#transformt-s-s),
+[`TRANSFORM(t, t, s)`](#transformt-t-s), [`TRANSFORM(t, d, s)`](#transformt-d-s)
+and [`TRANSFORM(t, s, s, s)`](#transformt-s-s-s) functions for transforming
+from one time resolution to another. To get an overview of all the
+transformation function variants, see [which functions can be used when?](../functions/transform_what_when.md)
+
+
+## Output resolution
 
 Transformation of time series from one resolution to another resolution is
 specified by symbols like HOUR, DAY, WEEK etc. Some of these symbols have a time
@@ -12,51 +16,78 @@ zone foundation. For example, DAY can be related to European Standard Time
 zone argument to TRANSFORM is omitted, the configured standard time zone with no
 Daylight Saving Time enabled is used.
 
-The TRANSFORM function is also used internally in the system when there is a
-request for time series values with a resolution that is different from its
-native definition. For example, it can be used as part of presenting a DAY based
-series into an HOUR based presentation, or vice versa. When doing this, the
-system will check if there are presentation hints available, as well as inspect
-the time series type and value unit to come up with reasonable arguments to the
-TRANSFORM operation.
+| Symbol | Description               |
+| ------ | ------------------------- |
+| MIN    | Fixed 1 minute interval   |
+| MIN5   | Fixed 5 minute interval   |
+| MIN10  | Fixed 10 minute interval  |
+| MIN15  | Fixed 15 minutes interval |
+| MIN30  | Fixed 30 minutes interval |
+| HOUR   | Fixed hour interval       |
+| DAY    | Fixed day interval        |
+| WEEK   | Fixed week interval       |
+| MONTH  | Fixed month interval      |
+| YEAR   | Fixed year interval       |
 
-**Note!** In the mentioned example, the time zone used will always be the
-configured standard time zone. If this default behaviour appears to be wrong for
-your business process, you have to make a transformation that uses explicit
-TRANSFORM expressions in virtual time series or as part of a time series report.
 
-If the transformation is done from a fixed interval series to a variable
-interval series (breakpoint resolution), you may need to use additional status
-mask filtering to achieve the result you expect. This is mostly relevant when
-there are NaN values in the fixed resolution source series, because such value
-points are transformed to a NaN value with time from the start of each fixed
-resolution interval. If you want the breakpoint series to not contain explicit
-NaN values you have to combine the TRANSFORM function with STATUS_MASK as shown
-in example below:
+## Transformation methods
 
-`## = @STATUS_MASK(@TRANSFORM(@t('.FixedSourceSeriesWithNaNValues'),'VARINT','DEFAULT'), 'missing', 'remove')`
+All the `TRANSFORM` functions take a a transformation method argument which
+determines the values and flags of the output time series. The following
+subsections document the valid transformation methods.
 
-The STATUS_MASK wrapper removes values with status missing from the transformed
-time series.
+Transforming from breakpoint to any resolution uses the "finer to coarser"
+table, as does the `@TRANSFORM(t, t, s)` function.
 
-### R1
-## About the function
+
+### Transforming from a finer to a coarser resolution
+
+| Symbol | Description |
+| ------ | - |
+| SUM    | The sum of the values included in the base for this value.<br/><br/>Does not consider how long the values are valid, i.e. a break point series with two values in the current interval that will give the sum of these two values. |
+| SUMI   | Integral based sum with resolution second. Calculates the sum of value multiplied with number of seconds each value is valid.<br/><br/>Value equal 1 at the start of the day will give 86400 as day value if the base is one break point series and 3600 if this is an hour series with only one value on first hour. |
+| AVG    | For fixed interval series. Sum of all values in accumulation period divided by number of values in the accumulation period (24 for hour series that is transformed to day series).<br/><br/>For break point series: Mean value of the values included in the base for this value. Does not consider how long the values are valid, i.e. a break point series with two values in the current interval that will give the mean value of these two values. |
+| AVGI   | Integral based mean value, i.e. considers how much of the accumulation period that a given value is valid (to next value that can be NaN for a fixed interval series). This value is presented as mean value in the summary part of the presentation in Table. |
+| FIRST  | First value in the accumulation period. This is the functional value at the start of the accumulation period, unless there exists an explicit value. |
+| LAST   | Last value in the accumulation period. This is the functional value at the end of the accumulation period, unless there exists an explicit value. |
+| MIN    | Smallest value in the accumulation period. |
+| MAX    | Largest value in the accumulation period. |
+
+
+### Transforming from a coarser to a finer resolution
+
+| Symbol | Description                                                                                         |
+| ------ | --------------------------------------------------------------------------------------------------- |
+| SUM    | The sum of the result values for expanded period equals the value in the input data series.         |
+| AVG    | The mean values of the result values for expanded period equals the value in the input data series. |
+
+For `@TRANSFORM(t, s, s)`, `@TRANSFORM(t, s, s, s)`, and `@TRANSFORM(t, d, s)`
+the implementation chooses `SUM` if the method string contains (case insensitive)
+`SUM`, and `AVG` otherwise. This behaviour is deprecated and may be removed in
+a future version, preceded by tooling to identify erroneous cases. We strongly
+recommend using `SUM` or `AVG` instead of for example `SUMV` or `AVERAGE`.
+
+If the input time series is time zone aware we only allow `SUM` or `AVG`.
+
+
+## `TRANSFORM(t, s, s)`
+
 This is the most common conversion function. You can use it to convert both
 ways, i.e. both from finer to coarser resolution, and the other way. The most
 common use is accumulation, i.e. transformation to coarser resolution. Most
 transformation methods are available for this latter use.
 
-## Syntax
-- TRANSFORM(t,s,s)
 
-## Description
+### Description
 | # | Type | Description |
 |---|---|---|
 | 1 | t | Time series to be converted. |
 | 2 | s | Time resolution of the result, given as a RESOLUTION symbol (see separate table). |
 | 3 | s | Conversion method, given as a TRANSMETHOD symbol (see separate table). |
 
-## Example
+
+### Example
+
   Example 1: @TRANSFORM(t,s,s) Create week sums from a time series
 
   Res1 = @TRANSFORM(@t('HourTs'), 'WEEK', 'SUM')
@@ -97,23 +128,22 @@ transformation methods are available for this latter use.
 
   ![](assets/images/ex_TRANSFORM-nimbustable7.png)
 
-### R2
-## About the function
+
+## `TRANSFORM(t, t, s)`
+
 Conversion to periods given by points of time on the series given as argument 2.
 The result is a break point series. This function enables periods that are not
 standard calendar units, e.g. 3 hours, 10 days, etc.
 
-## Syntax
-- TRANSFORM(t,t,s)
 
-## Description
+### Description
 | # | Type | Description |
 |---|---|---|
 | 1 | t | Time series to be converted. |
 | 2 | t | Time resolution on result, given as a break point series. The result series contains values on the points of time that exist on this series for current period. The values on this series are not used. |
 | 3 | s | Conversion method, given as a TRANSMETHOD symbol. |
 
-## Example
+### Example
 If you want to create an 8 hour accumulation for a time series you may do like
 this:
 
@@ -125,36 +155,32 @@ this:
 
   Res is a result series with break point resolution.
 
-### R3
-## About the function
+
+## `TRANSFORM(t, d, s)`
+
 Conversions given by the number given as argument 2. The number represents
 number of seconds in the period.
 
-## Syntax
-- TRANSFORM(t,d,s)
-
-## Description
+### Description
 | # | Type | Description |
 |---|---|---|
 | 1 | t | Time series to be converted. |
 | 2 | d | Time resolution on the result, given as number of seconds in each period. |
 | 3 | s | Conversion method, given as a TRANSMETHOD symbol. |
 
-## Example
+### Example
 If d is defined as the value 864000 this means a period of 10 days
 (60*60*24*10). The result is a break point series.
 
-### R4
-## About the function
-Corresponding functionality as in [R1](#r1), but with an additional argument
-that decides which time zone that is the base for the conversion. This gives the
-possibilities to user periods that are different from the rest of the
-environment.
+## `TRANSFORM(t, s, s, s)`
 
-## Syntax
-- TRANSFORM(t,s,s,s)
+Corresponding functionality as in [`TRANSFORM(t, s, s)`](#transformt-s-s), but
+with an additional argument that decides which time zone that is the base for
+the conversion. This gives the possibilities to user periods that are different
+from the rest of the environment.
 
-## Description
+
+### Description
 | # | Type | Description |
 |---|---|---|
 | 1 | t | Time series to be converted. |
@@ -162,9 +188,9 @@ environment.
 | 3 | s | Conversion method, given as a TRANSMETHOD symbol. |
 | 4 | s | Symbol stating time zone. 'LOCAL', 'LOKAL' and 'LT' give local time zone, 'NORMAL', 'STANDARD' and 'NT' gives normal time zone. Otherwise, the system will perform a lookup and see whether the value of the symbol is the name on an explicitly stated time zone in the system. Unknown zone equals no zone and then normal time zone is used. |
 
-  **Example**
-If you wish to calculate the DAY average on every hour of the day with Daylight
-Saving Time (DST), you can make an expression like this :
+### Example
 
-Res = @TRANSFORM(@TRANSFORM(@t(‘HourSeries’), 'DAY', 'MEAN', 'LT'), 'HOUR',
-'MEAN', 'LT')
+If you wish to calculate the DAY average on every hour of the day with Daylight
+Saving Time (DST), you can make an expression like this:
+
+    @TRANSFORM(@TRANSFORM(@t(‘HourSeries’), 'DAY', 'AVG', 'LT'), 'HOUR', 'AVG')

--- a/docs/mesh/calculations/functions/transform.md
+++ b/docs/mesh/calculations/functions/transform.md
@@ -21,8 +21,8 @@ Daylight Saving Time enabled is used.
 | MIN    | Fixed 1 minute interval   |
 | MIN5   | Fixed 5 minute interval   |
 | MIN10  | Fixed 10 minute interval  |
-| MIN15  | Fixed 15 minutes interval |
-| MIN30  | Fixed 30 minutes interval |
+| MIN15  | Fixed 15 minute interval  |
+| MIN30  | Fixed 30 minute interval  |
 | HOUR   | Fixed hour interval       |
 | DAY    | Fixed day interval        |
 | WEEK   | Fixed week interval       |
@@ -32,7 +32,7 @@ Daylight Saving Time enabled is used.
 
 ## Transformation methods
 
-All the `TRANSFORM` functions take a a transformation method argument which
+All the `TRANSFORM` functions take a transformation method argument which
 determines the values and flags of the output time series. The following
 subsections document the valid transformation methods.
 

--- a/docs/mesh/calculations/functions/transform_terms.md
+++ b/docs/mesh/calculations/functions/transform_terms.md
@@ -1,96 +1,15 @@
 # Terms used in the functions
 
-The functions in this category are used to calculate time series with a different time resolution than the source. The result can be in the following resolution:
-
-## Table 1: RESOLUTION symbol values
-
-| RESOLUTION symbol | Description |
-|---|---|
-| VARINT | Break point series, i.e. free distance between each point of time with value. |
-| MIN15 | Fixed 15 minutes interval |
-| MIN30 | Fixed 30 minutes interval |
-| HOUR | Fixed hour interval |
-| DAY | Fixed day interval |
-| WEEK | Fixed week interval |
-| MONTH | Fixed month interval |
-| YEAR | Fixed year interval |
-
-## Table 2a: TRANSMETHOD Symbol values valid in transformation to coarser time resolution
-
-| TRANSMETHOD Symbol | Description |
-|---|---|
-| SUM<br/>SUMV | The sum of the values included in the base for this value.<br/><br/>Does not consider how long the values are valid, i.e. a break point series with two values in the current interval that will give the sum of these two values. |
-| SUMI | Integral based sum with resolution second. Calculates the sum of value multiplied with number of seconds each value is valid.<br/><br/>Value equal 1 at the start of the day will give 86400 as day value if the base is one break point series and 3600 if this is an hour series with only one value on first hour. |
-| MEAN<br/>AVG or AVGV<br/>AVERAGE | For fixed interval series. Sum of all values in accumulation period divided by number of values in the accumulation period (24 for hour series that is transformed to day series).<br/><br/>For break point series: Mean value of the values included in the base for this value. Does not consider how long the values are valid, i.e. a break point series with two values in the current interval that will give the mean value of these two values. |
-| AVGI | Integral based mean value, i.e. considers how much of the accumulation period that a given value is valid (to next value that can be NaN for a fixed interval series). This value is presented as mean value in the summary part of the presentation in Table. |
-| FIRST | First value in the accumulation period. This is the functional value at the start of the accumulation period, unless there exists an explicit value. |
-| LAST | Last value in the accumulation period. This is the functional value at the end of the accumulation period, unless there exists an explicit value. |
-| MIN | Smallest value in the accumulation period. |
-| MAX | Largest value in the accumulation period. |
-
-Observe that in case the transformation method is integral based (for example ACCAVGI and ACCAVGI_NOW), the source series must have curvetype staircase start of step.
-
-For accumulation with base in break point series, you have the following particular methods that consider current period in a special way.
-
-## Table 2b: Special accumulation methods
-
-| TRANSMETHOD Symbol | Description |
-|---|---|
-| ACCVOLUME | Transforms meter reading values with random solution to a fixed interval period. This is done by calculating the functional value at interval points of time, calculate integral based mean for the resolution interval and then change up to next interval. Note! There is also a separate function to do this transformation, @Metered2Volume |
-| ACCM2V | See ACCVOLUME |
-
-## Table 3: TRANSMETHOD symbol values valid in transformation to finer time resolution
-
-| TRANSMETHOD Symbol | Description |
-|---|---|
-| SUM | The sum of the result values for expanded period equals the value in the input data series. |
-| MEAN<br/>AVERAGE | The mean values of the result values for expanded period equals the value in the input data series. |
-
-## Explicit default transformation
-
-If you state transformation code DEFAULT, the system will decide method from value type and value unit on the series. These are the rules that are taken into account:
-
-| TRANSMETHOD equals DEFAULT<br/>Unit/type | Description |
-|---|---|
-| Time series type of type linear | Here the first value in the base series is used, i.e. code FIRST |
-| Value unit<br/>Celsius, MM3, MW<br/>MWh/h, kWh/h<br/>Meter<br/>%, % of max, % of normal<br/>M3/s, MW/Hz<br/>NOK/MWh, SEK/MWh, EUR/MWh<br/>Liter/s, Liter/s/km2<br/>Meter/s | Here mean value is used as method. AVG for fixed interval series and for break point series AVGI is used, integral based mean value. |
-| Value unit<br/>mm, cm<br/><br/>And value type:<br/>snow depth, snow water equivalent<br/>ground water level, soil moisture | Here mean value is also used as method.<br/><br/>For break point series AVGI is used, integral based mean value. |
-| Otherwise when accumulating | Mean value method AVGI for break point series and SUM for fixed interval series. |
-| **When transforming to a finer resolution** | |
-| General | SUM, i.e. value is divided on number of points in this that covers new resolution |
-| MW, kW and more | Mean value (AVG) |
-
-If the environment variable ICC_TSRSERVER_VARINT_SUMI_ON_ACCUMULATE is defined, break point series that do not have step type linear will always be accumulated with method SUMI.
-
-## Implicit default transformation
-
-A time series report definition can include an attribute stating that the presentation e.g. should have week resolution even if the report only consists of hour series. From presentation in table you can also select a different resolution. It is i.e. necessary to transform hour values to week values without stating how this is done through a calculation expression. This is called implicit default transformation.
-
-Basically the same rules as described under Explicit default transformation are used. But you can influence how this should happen by setting attributes on columns. This is controlled by the attribute TYPE with value {method}, where method can be one of these values:
-
-ACCSUM, ACCSUMI,
-
-ACCAVG, ACCAVGI, ACCMEAN
-
-ACCFIRST, ACCLAST,
-
-ACCMIN, ACCMAX,
-
-ACCLAST_NOW, ACCAVGI_NOW, ACCSUMI_NOW
-
-These are the same codes defined in TRANSMETHOD but with prefix ACC. The explanation for the symbols is the same as the corresponding TRANSMETHOD documentation.
-
-Example on transformation attribute in a column definition:
-
-TYPE {ACCMIN}
 
 ## Mask series
 
 In some of the functions the term mask series is used. This is a time series where you separate between the values NaN, 0 and all other values. NaN and 0 are logically perceived as logically untrue value (FALSE) and all other values are perceived as logically true value (TRUE). A mask series can e.g. be used to define which hours that should be included in the calculation of a day value with method SUM.
 
+
 ## Profile series
 
 In some of the functions the term profile series is used. This is a time series that can be used in transformation to finer resolution, e.g. from day to hour. In this function you can either use mean value or sum consideration, i.e. if the mean value from calculated values should equal the value they were derived from or if it is the sum of the values that should equal the start point value.
+
 
 ## Handling profile
 
@@ -99,6 +18,7 @@ The profile series can be used in two ways, relative or absolute. Current functi
 ![Profile handling diagram](assets/images/image10.gif)
 
 The figure shows that use of relative profile will strengthen the variation if the mean value for the input data series (V) is large compared to the mean value on the profile series (M). By using absolute profile the variation will equal the profile series, possibly adjusted with a factor different from 1 that is given as first argument to the functions using absolute profile.
+
 
 ## Input data series
 

--- a/docs/mesh/calculations/functions/transform_what_when.md
+++ b/docs/mesh/calculations/functions/transform_what_when.md
@@ -8,7 +8,7 @@ This means transforming from a break point series to a fixed interval series, or
 
 For this type of task this is used:
 
-R1 = [@TRANSFORM(t,s,s)](../functions/transform.md#r1)
+R1 = [@TRANSFORM(t,s,s)](../functions/transform.md#transformt-s-s)
 
 ### ACCUMULATE VALUES TO SPECIFIC RESOLUTIONS
 
@@ -16,10 +16,10 @@ This means transformation from one time series to a different time series with a
 
 For this type of tasks the following are used:
 
-R2 = [@TRANSFORM(t,t,s)](../functions/transform.md#r2)
+R2 = [@TRANSFORM(t,t,s)](../functions/transform.md#transformt-t-s)
 
 
-R3 = [@TRANSFORM(t,d,s)](../functions/transform.md#r3)
+R3 = [@TRANSFORM(t,d,s)](../functions/transform.md#transformt-d-s)
 
 ### MAKE TRANSFORMATION WITH REFERENCE TO TIME ZONE
 
@@ -27,7 +27,7 @@ The calculator performs calculations with reference to normal time if nothing el
 
 For this type of task the following is used:
 
-R4 = [@TRANSFORM(t,s,s,s)](../functions/transform.md#r4)
+R4 = [@TRANSFORM(t,s,s,s)](../functions/transform.md#transformt-s-s-s)
 
 ### DISTRIBUTING VALUES WITH REFERENCE TO PROFILE
 


### PR DESCRIPTION
* Remove `SUMV`, `AVGV` and `AVERAGE` from the table of transformation methods from finer to coarser. These are not supported and result in errors.

* Remove `MEAN` from the table of transformation methods from finer to coarser and `MEAN` and `AVERAGE` from the table of transformation methods from coarser to finer. These work, but are deprecated in favour of `AVG`, which does the same thing.

* Add `AVG` to the table of transformations from coarser to finer.

* Remove the table of special transformation methods. This functionality doesn't exist.

* Remove `VARINT` from the resolution table and remove mentions of transformation to breakpoint series. Mesh cannot do that.

* Add `MIN`, `MIN5`, and `MIN10` to the `RESOLUTION` table.

* Move the `RESOLUTION` and `TRANSMETHOD` tables to `transform.md`. These tables are not relevant to any of the other functions in the section.

* Document the "contains SUM" rule for transformations from finer to coarser.

* Remove sections on implicit and explicit default transformations. These are variously wrong, unhelpful, and not applicable to calculations.

* Remove the last `LT` from the `TRANSFORM(t, s, s, s)` example. For transformations from coarser to finer resolutions the calendar argument is redundant and `TRANSFORM(@t('.day'), 'HOUR', 'AVG', 'LT')` is the same as `TRANSFORM(@t('.day'), 'HOUR', 'AVG')`.

* Mildly reword and reformat `transform.md`.

There's certainly more to be done here, but this should be a meaningful improvement on the current text.