### PR TITLE
Revert "mesh.json: Document FailOnSynchErrors set to true by default (#132)"

### DIFF
--- a/docs/mesh/installation/MeshServiceInstallationGuide.md
+++ b/docs/mesh/installation/MeshServiceInstallationGuide.md
@@ -797,7 +797,7 @@ Below is the complete `mesh.json` listed with all options with default values.
 
 ```json
 {
-  "FailOnSynchErrors": true,  // Specifies whether Mesh should shut down after 3 consecutive synchronisation errors
+  "FailOnSynchErrors": false,  // Specifies whether Mesh should shut down after 3 consecutive synchronisation errors
   "SerializationVersion": 25,
   "MaxSessions": 250, // Maximum number of existing sessions at any given time, -1 to set to unlimited
   "ComputerName": "localhost",


### PR DESCRIPTION
This reverts commit 96a3c870eb4328b4703e1a23836c30e40584f338.

We decided to revert this change for now since it doesn't apply to 2026.3.
If we re-generate the current docs for 2026.3, this change would be
erroneously included there too.