### PR TITLE
unify header structure in Mesh calc functions

### DIFF
--- a/docs/mesh/calculations/functions/abs.md
+++ b/docs/mesh/calculations/functions/abs.md
@@ -1,4 +1,4 @@
-﻿## ABS
+﻿# ABS
 ## About the function
 This function is used to determine the absolute value(s) for a time series.
 

--- a/docs/mesh/calculations/functions/accumulate.md
+++ b/docs/mesh/calculations/functions/accumulate.md
@@ -1,5 +1,7 @@
 # ACCUMULATE
 
+## About the function
+
 Accumulates values for some periods for a time series. When entering a new sub
 period, the accumulation buffer is reset.
 
@@ -9,7 +11,9 @@ period, the accumulation buffer is reset.
 - ACCUMULATE(t,[s],s)
 - ACCUMULATE(t,s,d)
 
-**Description** - syntax 1
+## ACCUMULATE(d,s,t[,d,d]) - syntax 1
+
+### Description
 
 | # | Type | Description |
 |---|---|---|
@@ -19,7 +23,9 @@ period, the accumulation buffer is reset.
 | 4 | d | Multiplication factor A. If omitted, value is 1.0. |
 | 5 | d | Offset factor B. If omitted, value is 0. |
 
-**Description** - syntax 2
+## ACCUMULATE(t,[s],s) - syntax 2
+
+### Description
 
 | # | Type | Description |
 |---|---|---|
@@ -27,7 +33,9 @@ period, the accumulation buffer is reset.
 | 2 | s | Optional. Accumulation from start or end of the interval given in the next argument. <br>’>’ means from the start of the interval and forward. |
 | 3 | s | Accumulation interval. Eg. ‘DAY’, ‘WEEK’, ‘MONTH, ‘YEAR’. <br>You can set accumulation period to HYDYEAR, i.e. from 1. September <br>until next 1. September (standard calendar). <br>You can also use a prefix to overrule the standard time (utc+1 in Norwegian setup). <br>Eg. ‘UTCWEEK’. |
 
-**Description** - syntax 3
+## ACCUMULATE(t,s,d) - syntax 3
+
+### Description
 
 | Type | Description |
 |---|---|
@@ -35,7 +43,9 @@ period, the accumulation buffer is reset.
 | s | Must be ’>’. |
 | d | Accumulation period given as number of points. |
 
-## Example 1
+## Examples
+
+### Example 1
 
 Accumulation syntax 1 with five arguments
 
@@ -56,7 +66,7 @@ Result[t] = Result[t-1] + factor A * TsAccInput[t] + factor B
 
 for the next values.
 
-## Example 2
+### Example 2
 
 Accumulation syntax 1 with three arguments (uses default values for factor A and B (argument four and five))
 
@@ -65,7 +75,7 @@ Accumulation syntax 1 with three arguments (uses default values for factor A and
 The example starts accumulation 10th of January (UTC calendar) with initial
 value 0.0. No multiplication or offset factors are used.
 
-## Example 3
+### Example 3
 
 Accumulation syntax 2
 
@@ -75,7 +85,7 @@ Accumulates the precipitation for each hydrological year.
 
 ![](assets/images/ex_accumulate.png)
 
-## Example 4
+### Example 4
 
 Accumulation syntax 2 with second argument omitted.
 
@@ -85,7 +95,7 @@ Accumulates the precipitation for each week.
 
 ![](assets/images/ex_accumulate2.png)
 
-## Example 5
+### Example 5
 
 Accumulation of bucket precipitation using explicit extended periods
 

--- a/docs/mesh/calculations/functions/acos.md
+++ b/docs/mesh/calculations/functions/acos.md
@@ -1,5 +1,5 @@
-﻿## ACOS
-**About the function**
+﻿# ACOS
+## About the function
 
 Arc cosinus to values on given time series.
 
@@ -7,7 +7,7 @@ The function takes a time series as argument and returns the result as a time
 series with the same properties as argument. **Note!** The values of the result
 are in radians.
 
-**Syntax**
+## Syntax
 
 - ACOS(t)
 

--- a/docs/mesh/calculations/functions/asin.md
+++ b/docs/mesh/calculations/functions/asin.md
@@ -1,5 +1,5 @@
-﻿## ASIN
-**About the function**
+﻿# ASIN
+## About the function
 
 Arc sine to values on given time series.
 
@@ -7,7 +7,7 @@ The function takes a time series as argument and returns the result as a time
 series with the same properties as argument. **Note!** The values of the result
 are in radians.
 
-**Syntax**
+## Syntax
 
 - ASIN(t)
 

--- a/docs/mesh/calculations/functions/at.md
+++ b/docs/mesh/calculations/functions/at.md
@@ -1,17 +1,17 @@
-﻿## AT
+﻿# AT
 
-### About the function
+## About the function
 
 Retrieves an element from an object. Relevant object types are array of time
 series, numbers or time series.
 
-### Syntax
+## Syntax
 
 - AT(T,d)
 - AT(D,d)
 - AT(t,s)
 
-### Description
+## Description
 
 | # | Type | Description |
 |---|---|---|

--- a/docs/mesh/calculations/functions/atan.md
+++ b/docs/mesh/calculations/functions/atan.md
@@ -1,5 +1,5 @@
-﻿## ATAN
-**About the function**
+﻿# ATAN
+## About the function
 
 Arc tangent to values on given time series.
 
@@ -7,7 +7,7 @@ The function takes a time series as argument and returns the result as a time
 series with the same properties as the argument. **Note!** The values of the
 result are in radians.
 
-**Syntax**
+## Syntax
 
 - ATAN(t)
 

--- a/docs/mesh/calculations/functions/bool.md
+++ b/docs/mesh/calculations/functions/bool.md
@@ -30,7 +30,7 @@ resolution as the input time series.
   ![](assets/images/ex_BOOL-nimbustable1.png)
 
 ## Examples
-### Example 1: 
+### Example 1: @BOOL(d)
 ```
 @BOOL(d)
 @BOOL(NaN) Returns 0.

--- a/docs/mesh/calculations/functions/ceil.md
+++ b/docs/mesh/calculations/functions/ceil.md
@@ -1,4 +1,4 @@
-## CEIL
+# CEIL
 ## About the function
 This function rounds off values in a time series up to the nearest whole number.
 
@@ -11,7 +11,7 @@ The function can also be applied to a single number.
 - CEIL(t)
 - CEIL(d)
 
-**Description**
+## Description
 
 | # | Type | Description |
 |---|---|---|

--- a/docs/mesh/calculations/functions/color.md
+++ b/docs/mesh/calculations/functions/color.md
@@ -10,7 +10,7 @@ template reports.
 
 - ColorARGB(s)
 
-### Description
+## Description
 
 | # | Type | Description |
 |---|---|---|
@@ -44,7 +44,7 @@ steelblue3
 steelblue4
 ```
 
-### Example
+## Example
 
   `## = @t('.Income') > 1000 ? @ColorARGB('orange') : @ColorARGB('magenta')`
 

--- a/docs/mesh/calculations/functions/concatenate.md
+++ b/docs/mesh/calculations/functions/concatenate.md
@@ -25,7 +25,9 @@ variant is recommended:
 |---|---|---|
 | 1 | S | An array of texts to concatenate into the resulting text |
 
-## Example 1
+## Examples
+
+### Example 1
 
   `## = @t(@Concatenate(‘../...’, @s(‘.TargetTimeseries’))`
 
@@ -35,7 +37,7 @@ The argument to @t is calculated based on the local text attribute
 this, `../...MyTs`. This means go to the parent of the parent and get the time
 series on the *MyTs* attribute.
 
-## Example 2
+### Example 2
 
 `## = @t( @Concatenate( {'*[.Type=HydroPlant&&.Name=', @MeshID('NAME'),'].Production' })`
 

--- a/docs/mesh/calculations/functions/convert_volume.md
+++ b/docs/mesh/calculations/functions/convert_volume.md
@@ -1,5 +1,5 @@
-## CONVERT_VOLUME
-  About the functions
+# CONVERT_VOLUME
+## About the function
 
 Converts a time series unit into a new unit. The result series has the same
 resolution as the input time series.

--- a/docs/mesh/calculations/functions/copy_ts.md
+++ b/docs/mesh/calculations/functions/copy_ts.md
@@ -1,15 +1,17 @@
-﻿## CopyTs
+﻿# CopyTs
+
+## About the function
 
 This function copies values from a source location to a destination location
 within the Mesh model. This is a function where the "side effects" of the
 operation is the important part rather than the returned values.
 
-### Syntax
+## Syntax
 
 - CopyTs(s,s,s)
 - CopyTs(s,s,s,s)
 
-**Description**
+## Description
 
 | Type | Description |
 |---|---|
@@ -18,7 +20,7 @@ operation is the important part rather than the returned values.
 | s | Search expression for getting target time series. By default relative to the object where the @CopyTs() calculation is found. Prefix with "Model:" to make the search relative to model root. This part is removed before applying the search. |
 | s | (optional) Execution mode: `Strict`, `Pragmatic`, `AllSources`, or `AllTargets`. Defaults to `Pragmatic` when omitted (3-argument form). |
 
-**Execution modes**
+### Execution modes
 
 | Mode | Description |
 |---|---|
@@ -27,7 +29,7 @@ operation is the important part rather than the returned values.
 | AllSources | All source series must find at least one matching target. |
 | AllTargets | All target series must receive values from a source. |
 
-**Return value**
+### Return value
 
 The function returns a non-negative value representing the number of target time
 series that were successfully copied to. A negative value indicates an error.
@@ -35,7 +37,7 @@ series that were successfully copied to. A negative value indicates an error.
 A target time series can only receive values from one source. If multiple
 sources match the same target, the function returns an error.
 
-### Example
+## Example
 
 `## = @CopyTs('Ident', '*[.Type=TypeB].Ts1','Model:*[.Name=A1_3_New]/[.Type=TypeB].Ts1')`
 

--- a/docs/mesh/calculations/functions/correct_average_value.md
+++ b/docs/mesh/calculations/functions/correct_average_value.md
@@ -1,16 +1,18 @@
-## CorrectAverageValue
-**About the function**
+# CorrectAverageValue
+## About the function
 
 The method replaces values marked as errors with the average value of other
 series for the same time. Values with correction using average value are set to
 corrected and marked with **C05**, meaning correction method 5. You can see this
 code if you turn on value information in Nimbus.
 
-**Syntax**
+## Syntax
 
 - CorrectAverageValue(t,d,s,s,d,T,D,S)
 
-Description CorrectAverageValue(t,d,s,s,d,T,D,D,D,S)
+## Description
+
+CorrectAverageValue(t,d,s,s,d,T,D,D,D,S)
 
 | # | Type | Description |
 |---|---|---|
@@ -33,7 +35,8 @@ correction must not include the same function. E.g you might refer to a time
 series using only validation functions or other correction function that is not
 depending on other time series. This is caused by the virtual calculation in
 Mesh.
-**Example**
+
+## Example
 
 ```
 Temperature_hour_VEE = @CorrectAverageValue(@t('ValidatedTimeSeries'),0.95,'TRUE','FALSE',1,@T('../NeighbourMetStations/Temperature_hour_avg'),@D('../NeighbourMetStations/Weight'),@S('../NeighbourMetStations/AcceptCorrected'))

--- a/docs/mesh/calculations/functions/correct_constant_value.md
+++ b/docs/mesh/calculations/functions/correct_constant_value.md
@@ -1,12 +1,12 @@
-﻿## CorrectConstantValue
-**About the function**
+﻿# CorrectConstantValue
+## About the function
 
 Corrects errors on a previously validated time series with a specified constant
 value. Values with correction using constant value are set to corrected and
 marked with **C01**, meaning correction method 1. You can see this code if you
 turn on value information in Nimbus.
 
-**Syntax**
+## Syntax
 
 - CorrectConstantValue(t,d)
 
@@ -17,7 +17,7 @@ turn on value information in Nimbus.
 | 1 | t | Time series to be corrected. |
 | 2 | d | Constant value to use when correcting. |
 
-**Example**
+## Example
 
 `Waterlevel_hour_VEE = @CorrectConstantValue(@ValidateAbsLimit(@t('Waterlevel_hour_raw'),207,210),208)`
 

--- a/docs/mesh/calculations/functions/correct_copy_value.md
+++ b/docs/mesh/calculations/functions/correct_copy_value.md
@@ -1,12 +1,12 @@
-﻿## CorrectCopyValue
-**About the function**
+﻿# CorrectCopyValue
+## About the function
 
 Corrects errors on a previously validated time series using a copy of the
 previous value. Values with correction using copy value are set to corrected and
 marked with **C02**, meaning correction method 2. You can see this code if you
 turn on value information in Nimbus.
 
-**Syntax**
+## Syntax
 
 - CorrectCopyValue(t,d,s)
 
@@ -18,7 +18,7 @@ turn on value information in Nimbus.
 | 2 | d | Value describing the maximum number of allowed copies. |
 | 3 | s | Symbol describing whether or not corrected values can be used. This is specified as either 'TRUE' or 'FALSE'. |
 
-**Example**
+## Example
 
 `Waterlevel_hour_VEE = @CorrectCopyValue(@ValidateAbsLimit(@t('Waterlevel_hour_raw'),207,210),3,'TRUE')`
 

--- a/docs/mesh/calculations/functions/correct_extrapolate.md
+++ b/docs/mesh/calculations/functions/correct_extrapolate.md
@@ -1,12 +1,12 @@
-﻿## CorrectExtrapolate
-**About the function**
+﻿# CorrectExtrapolate
+## About the function
 
 Corrects errors on a previously validated time series using extrapolation.
 Values with correction using extrapolation are set to corrected with remark C04,
 meaning correction method 4. You can see this code if you turn on value
 information in Nimbus.
 
-**Syntax**
+## Syntax
 
 - CorrectExtrapolate(t,d,s)
 

--- a/docs/mesh/calculations/functions/correct_interpolate.md
+++ b/docs/mesh/calculations/functions/correct_interpolate.md
@@ -1,12 +1,12 @@
-## CorrectInterpolate
-  **About the function**
+# CorrectInterpolate
+## About the function
 
 Corrects errors on a previously validated time series using interpolation.
 Values with correction using interpolation are set to corrected and marked with
 **C03**, meaning correction method 3. You can see this code if you turn on value
 information in Nimbus.
 
-  **Syntax**
+## Syntax
 
 - CorrectInterpolate(t,d,s)
 

--- a/docs/mesh/calculations/functions/cos.md
+++ b/docs/mesh/calculations/functions/cos.md
@@ -1,4 +1,4 @@
-﻿## COS
+﻿# COS
 ## About the function
 This function is used to calculate the cosine of a time series. **Note!** The
 values of the input are in radians.

--- a/docs/mesh/calculations/functions/delta.md
+++ b/docs/mesh/calculations/functions/delta.md
@@ -1,17 +1,17 @@
-﻿## DELTA
+﻿# DELTA
 
-### About the function
+## About the function
 
 Finds the difference between values in a time
 series. A typical usage is to calculate the change between value at a time point and the previous time point, but there are other options that are controlled by the arguments to the function.
 
 The result series has the same resolution as the input time series.
 
-### Syntax
+## Syntax
 
 - DELTA(t[,d|s])
 
-### Description
+## Description
 
 | # | Type | Description |
 |---|---|---|
@@ -31,9 +31,9 @@ DELTA(t,’-2h’): res(t) = y(t) – y(t -2h) Second argument has value ‘-2h�
 The input time series might be a fixed interval series or a variable interval
 series.
 
-### Examples
+## Examples
 
-#### Example 1
+### Example 1
 
 H_Ts1 is an hourly time series with some empty values.
 
@@ -55,7 +55,7 @@ H_Ts1 is an hourly time series with some empty values.
 
 As the result series shows, an empty value is treated as 0 in these delta calculations.
 
-#### Example 2
+### Example 2
 
 `Result = @DELTA(@t('.H_Ts1'),'+2h')`
 
@@ -75,7 +75,7 @@ As the result series shows, an empty value is treated as 0 in these delta calcul
 
 In this case, a value at time t is based on the difference between the value 2 hours ahead and the value at t.
 
-#### Example 3
+### Example 3
 
 BP_Ts1 is a time series with breakpoint resolution.
 
@@ -91,7 +91,7 @@ There is no value before the value at 2021-12-31T23:00:00Z on BP_Ts1 series.
 When the input series has breakpoint resolution, empty value is treated differently compared to fixed interval.
 We see this in the first value (nan) on the result series. 
 
-#### Example 4
+### Example 4
 
 BP_Ts1 is a time series with break point resolution and _linear_ curve type.
 
@@ -106,7 +106,7 @@ BP_Ts1 is a time series with break point resolution and _linear_ curve type.
 
 **_Note_!** Due to the linear curve type of the input series, the result value is based on the functional value at offset hours.
 
-#### Example 5
+### Example 5
 
 `TemperatureForecast_delta = @DELTA(@t('AreaTemperature'))`
 

--- a/docs/mesh/calculations/functions/disable_cache.md
+++ b/docs/mesh/calculations/functions/disable_cache.md
@@ -1,5 +1,7 @@
 # DisableCache
 
+## About the function
+
 The `@DisableCache()` function disables caching of calculation results for
 the calculation expression it is used in and all calculations referencing that
 calculation. `@DisableCache()` may be used for debugging purposes or to work

--- a/docs/mesh/calculations/functions/distribute.md
+++ b/docs/mesh/calculations/functions/distribute.md
@@ -1,4 +1,4 @@
-﻿## DISTRIBUTE
+﻿# DISTRIBUTE
 This topic describes DISTRIBUTE variants ([R6](#r6), [R7](#r7), [Ra7](#ra7)) for
 transforming from one time resolution to another.
 
@@ -6,25 +6,25 @@ To get an overview of all the transformation function variants, see:
 
 [Which functions can be used when?](../functions/transform_what_when.md)
 
-### R6
-## About the function
+## R6
+### About the function
 Converts a time series to a finer resolution. The resolution for the result is
 given by the resolution of the mask series defined in argument 2. The value from
 the series in argument 1 is distributed to the points of time in the mask series
 having logical true value (different from 0 and NaN). The function uses the SUM
 method as base for the distribution.
 
-## Syntax
+### Syntax
 - DISTRIBUTE(t,t)
 
-## Description
+### Description
 
 | Type | Description |
 |---|---|
 | t | Input time series to be distributed. |
 | t | Mask series representing the distributed time interval. |
 
-## Example
+### Example
 `MaskSeries = @TIME_MASK('HOUR',{'HOUR','HOUR+15x','HOUR+30x','HOUR+45x'},{1,2,3,2},'MIN15)`
 
 `ResultTimeSeries = @DISTRIBUTE(@t('Ts5'),MaskSeries)`
@@ -48,15 +48,15 @@ The result will be a break point time series.
 
 ![](assets/images/ex_DISTRIBUTE-nimbustable3.png)
 
-### R7
-## About the function
+## R7
+### About the function
 As function [R6](#r6), but with a third argument which is a profile series. This
 decides how the distribution of the values is done.
 
-## Syntax
+### Syntax
 - DISTRIBUTE(t,t,t)
 
-## Description
+### Description
 
 | Type | Description |
 |---|---|
@@ -78,7 +78,7 @@ Pi = Profile value for the time point i in the result time series
 
 MI = Calculated mean value for the profile series for the distributed period
 
-## Example
+### Example
 `MaskSeries/Profile = @TIME_MASK('HOUR',{'HOUR','HOUR+15x','HOUR+30x','HOUR+45x'},{1,2,3,2},'MIN15')`
 
 Argument 2 is a mask series (all time points contributes)
@@ -94,16 +94,16 @@ like this:
 
 FirstValue = 2 / 4 * 1 / 2 = 0,25
 
-### Ra7
-## About the function
+## Ra7
+### About the function
 As function [R7](#r7), but with a scaling factor in argument 1. This DISTRIBUTE
 variant gives values on the result series also for the value 0 on the input data
 series (given that the profile series has different values in the period).
 
-## Syntax
+### Syntax
 - DISTRIBUTE(d,t,t,t)
 
-## Description
+### Description
 
 | Type | Description |
 |---|---|
@@ -119,7 +119,7 @@ The distribution of the values is done like this:
 K is a scaling factor coming from argument 1 in the function. The other symbols
 used in the formula are the same as described in [R7](#r7).
 
-Example 1
+### Example 1
 
 `MaskSeries/Profile = @TIME_MASK('HOUR',{'HOUR','HOUR+15x','HOUR+30x','HOUR+45x'},{1,2,3,2},'MIN15')`
 
@@ -136,7 +136,7 @@ like this:
 
 FirstValue = 2 / 4 + 1 ∙ (1 - 2) = -0,5
 
-Example 2
+### Example 2
 
 `MaskSeries/Profile = @TIME_MASK('HOUR',{'HOUR','HOUR+15x','HOUR+30x','HOUR+45x'},{1,2,3,2},'MIN15')`
 

--- a/docs/mesh/calculations/functions/floor.md
+++ b/docs/mesh/calculations/functions/floor.md
@@ -1,4 +1,4 @@
-## FLOOR
+# FLOOR
 ## About the function
 Converts the number in a time series to an integer by cutting all decimals.
 
@@ -11,7 +11,7 @@ The function can also be applied to a single number.
 - FLOOR(t)
 - FLOOR(d)
 
-**Description**
+## Description
 
 | # | Type | Description |
 |---|---|---|

--- a/docs/mesh/calculations/functions/get_all_forecasts.md
+++ b/docs/mesh/calculations/functions/get_all_forecasts.md
@@ -1,14 +1,16 @@
-## GetAllForecasts
+# GetAllForecasts
+
+## About the function
 
 Returns all time series versions that have values within the requested time period.
 
 ![](assets/images/GetAllForecasts.png)
 
-### Syntax
+## Syntax
 
 - GetAllForecasts(t) - returns an array of time series
 
-### Example
+## Example
 
 Example data is described [here](./history.md#hourly-example-data).
 

--- a/docs/mesh/calculations/functions/get_best_forecast.md
+++ b/docs/mesh/calculations/functions/get_best_forecast.md
@@ -1,4 +1,6 @@
-## GetBestForecast
+# GetBestForecast
+
+## About the function
 
 **_Note!_** This function is now obsolete.
 It returns the latest written value at all time points part of requested time period.
@@ -7,7 +9,7 @@ The figure below illustrates this. The returned series is a merge of the red seg
 
 ![](assets/images/GetBestForecast.png)
 
-### Example
+## Example
 
 The following expressions give the same result.
 

--- a/docs/mesh/calculations/functions/get_forecast.md
+++ b/docs/mesh/calculations/functions/get_forecast.md
@@ -1,4 +1,6 @@
-## GetForecast
+# GetForecast
+
+## About the function
 
 A forecast is typically received with a frequency and contains data for a duration, for instance 2 times a day with hourly data for 10 days forward.
 
@@ -10,7 +12,7 @@ called forecast set.
 
 There might be multiple versions that cover the same value time period.
 
-### Syntax
+## Syntax
 
 - GetForecast(t)
 - GetForecast(t,d|s,d|s)
@@ -20,7 +22,7 @@ The second, third and fourth argument is a time point definition, either given a
 
 The first value in a forecast write operation is associated with time point t0.
 
-### Description
+## Description
 
 | # | Type | Description |
 |---|---|---|
@@ -45,11 +47,11 @@ within the given interval, the function returns a time series with NaN.
 
 ![](assets/images/GetForecast2.png)
 
-### Examples
+## Examples
 
 The data used in these examples are described [here](./history.md#hourly-example-data).
 
-#### Get forecast based on requested time period
+### Get forecast based on requested time period
 
 `## = @GetForecast(@t('.Temperature_forecast'))`
 
@@ -91,7 +93,7 @@ The same expression, but now with a *tstart* one hour later: `UTC2025110603`.
 | 2025-11-06T15:00:00Z |       4.00 |       2.00 |
 | 2025-11-06T16:00:00Z |       4.10 |       2.00 |
 
-#### Get forecast with forecast start arguments
+### Get forecast with forecast start arguments
 
 The first forecast write (value 1) has a first value at  `UTC2025110523`.
 The second forecast write (value 2) has a first value at `UTC2025110603`, i.e. 4 hours later.

--- a/docs/mesh/calculations/functions/get_merged_forecast.md
+++ b/docs/mesh/calculations/functions/get_merged_forecast.md
@@ -1,4 +1,6 @@
-## GetMergedForecast
+# GetMergedForecast
+
+## About the function
 
 Returns a time series based on a specified segment for available forecast versions.
 
@@ -7,11 +9,11 @@ Returns a time series based on a specified segment for available forecast versio
 The returned series contains the red segments, in this example based on 
 a value segment [+6h->+12h] from each forecast.
 
-### Syntax
+## Syntax
 
 - GetMergedForecast(t,s)
 
-### Description
+## Description
 
 | # | Type | Description |
 |---|---|---|
@@ -24,7 +26,7 @@ To analyse the quality of the the third day in a forecast you can use a segment
 specification '2d:1d`.
 
 
-### Examples
+## Example
 
 Uses the example data described [here](./history.md#hourly-example-data).
 

--- a/docs/mesh/calculations/functions/get_ts_as_of_time.md
+++ b/docs/mesh/calculations/functions/get_ts_as_of_time.md
@@ -1,6 +1,6 @@
-## GetTsAsOfTime
+# GetTsAsOfTime
 
-### About the function
+## About the function
 
 Used to retrieve a physical time series as it was at a given historical time.
 
@@ -10,14 +10,14 @@ parameter number two.
 Note! If the historical time is earlier than the first write to the series (in
 the relevant period) then the function returns NaN values.
 
-### Syntax
+## Syntax
 
 - GetTsAsOfTime(t,s[,s])
 - GetTsAsOfTime(t,d[,s])
 - GetTsAsOfTime(t,S[,s]) - returns an array of time series
 - GetTsAsOfTime(t,D[,s]) - returns an array of time series
 
-### Description
+## Description
 
 | # | Type | Description |
 |---|---|---|
@@ -32,7 +32,7 @@ A tick is 100 nanoseconds, i.e. there are 10,000 ticks in a millisecond. Referen
 If a reference to a time series calculation is passed in the first argument, as
 in `@GetTsAsOfTime(@t('.Calc'), t)`, the calculation will fail with an error.
 
-### Examples
+## Examples
 
 Example time series have these historical values at given times:
 
@@ -43,32 +43,32 @@ Example time series have these historical values at given times:
 | October 12th 2012 00:00:00 | Ts_2 | 1 | 3 | 7 |   |
 | September 12th 2012 00:00:00 | Ts_3 | 1 | 3 | 8 |   |
 
-Example 1: GetTsAsOfTime(t,s)
+### Example 1: GetTsAsOfTime(t,s)
 
 `Res = GetTsAsOfTime(t0,'20121201000000000')`
 
 Returns time series Ts_1 which was valid December 1st 2012.
 
-Example 2: GetTsAsOfTime(t,s,s)
+### Example 2: GetTsAsOfTime(t,s,s)
 
 `Res = GetTsAsOfTime(t0,'20121201000000000','Delta')`
 
 Returns the difference between the values in Ts_0 and Ts_1: -1 2 5 8
 
-Example 3: GetTsAsOfTime(t,S)
+### Example 3: GetTsAsOfTime(t,S)
 
 `Res = GetTsAsOfTime(t0,{'20121201000000000','20121101000000000','20121001000000000'})`
 
 Returns an array of time series for the given times.
 
-Example 4: GetTsAsOfTime(t,S,s)
+### Example 4: GetTsAsOfTime(t,S,s)
 
 `Res = GetTsAsOfTime(t0,{'20121201000000000','20121101000000000','20121001000000000'},'DELTA')`
 
 Returns an array of the difference between the current time series and the time
 series at the given times.
 
-#### Example using GetTsAuditTimes
+### Example using GetTsAuditTimes
 
 The example data used is described [here](./history.md#hourly-example-data).
 

--- a/docs/mesh/calculations/functions/get_ts_audit_times.md
+++ b/docs/mesh/calculations/functions/get_ts_audit_times.md
@@ -1,6 +1,6 @@
-## GetTsAuditTimes
+# GetTsAuditTimes
 
-### About the function
+## About the function
 
 Returns an array of time points related to change events that have impact on values within the requested time period for the given time series. It is possible to restrict the number of time points returned.
 
@@ -18,14 +18,14 @@ get-date 638980320190000000
 November 6, 2025 13:20:19
 ```
 
-### Syntax
+## Syntax
 
 - GetTsAuditTimes(t,d) - returns array of numbers
 
 
-### Description
+## Description
 
-| # | Type | ## Description |
+| # | Type | Description |
 |---|---|---|
 | 1 | t | Time series. |
 | 2 | d | Desired maximum number of audit times for the time series. |

--- a/docs/mesh/calculations/functions/get_ts_historical_versions.md
+++ b/docs/mesh/calculations/functions/get_ts_historical_versions.md
@@ -1,14 +1,14 @@
-## GetTsHistoricalVersions
+# GetTsHistoricalVersions
 
-### About the function
+## About the function
 
 Returns an array of time series versions of a time series for the requested time period. The number of versions returned can be limited to a given number.
 
-### Syntax
+## Syntax
 
 - GetTsHistoricalVersions(t,d)
 
-### Description
+## Description
 
 | # | Type | Description |
 |---|---|---|
@@ -19,7 +19,7 @@ Note! If you ask for more versions than there exists, the system returns only
 the versions which exist. That is, potentially fewer than the number given as
 input to the function.
 
-### Examples
+## Examples
 
 GetTsHistoricalVersions(ts,1) returns the last change made, i.e. the latest
 historical version that is different from the current time series.

--- a/docs/mesh/calculations/functions/getyfx.md
+++ b/docs/mesh/calculations/functions/getyfx.md
@@ -1,6 +1,6 @@
-## GET_Y_FX
+# GET_Y_FX
 
-### About the function
+## About the function
 
 The function looks up in an xy-relation, defined as argument to the function,
 with values from a time series that also is an argument to the function. The
@@ -15,7 +15,7 @@ range](#handle-input-values-outside-the-provided-range).
 
 ## Description
 
-| # | Type | ## Description |
+| # | Type | Description |
 |---|---|---|
 | 1 | t | Series containing x-values used to lookup in the xy-relation to find <br>the result value for current point of time. |
 | 2 | D | X-values, sorted increasingly. |
@@ -24,7 +24,9 @@ range](#handle-input-values-outside-the-provided-range).
 
   GET_Y_FX (t,D,D,[s]) corresponds to y=f(x)
 
-## Example 1
+## Examples
+
+### Example 1
 
 ```
 R1 = @GET_Y_FX(%'/X series',{-1,20,40}, {1,2,3} )
@@ -57,7 +59,7 @@ When an input is higher than the last value from the x range provided in the
 function call (40 in the example below) the last value from the y range will be
 returned (3 in the example below).
 
-## Example 2
+### Example 2
 
 ```
 ##=@GET_Y_FX(@t('t'), {-1,20,40}, {1,2,3}, 'INTERPOL,NOHOLD')

--- a/docs/mesh/calculations/functions/gliding_trend_average.md
+++ b/docs/mesh/calculations/functions/gliding_trend_average.md
@@ -1,4 +1,4 @@
-﻿## GLIDING_TREND_AVERAGE
+﻿# GLIDING_TREND_AVERAGE
 ## About the function
 Reduces major fluctuations in a time series by calculating the future value on
 the basis of previous values.
@@ -8,7 +8,7 @@ The result series has the same resolution as the input time series.
 ## Syntax
 - GLIDING_TREND_AVERAGE(t,d[,d|D])
 
-**Description**
+## Description
 
 | # | Type | Description |
 |---|---|---|
@@ -17,8 +17,8 @@ The result series has the same resolution as the input time series.
 | 3 | d | Optional. Numerical value. If the value is different from 0, there will not be calculated any trend values outside the end period of the time series. |
 | 3 | D | Optional. D is a weighted array where the user can define which value is the most important. |
 
-## Example
-Example 1: GLIDING_TREND_AVERAGE(t,d)
+## Examples
+### Example 1: GLIDING_TREND_AVERAGE(t,d)
 
 `Waterlevel_hour_operative = @GLIDING_TREND_AVERAGE(@t('Waterlevel_hour_raw'),3)`
 
@@ -30,7 +30,7 @@ instance, in the table the average of the three closest previous values to Time
 
 ![](assets/images/ex_GLIDING_TREND_AVERAGE-nimbustable.png)
 
-Example 2: GLIDING_TREND_AVERAGE(t,d,D)
+### Example 2: GLIDING_TREND_AVERAGE(t,d,D)
 
 `Waterlevel_hour_operative = @GLIDING_TREND_AVERAGE(@t('Waterlevel_hour_raw'),3,{3,2,1})`
 

--- a/docs/mesh/calculations/functions/inside.md
+++ b/docs/mesh/calculations/functions/inside.md
@@ -1,4 +1,4 @@
-﻿## INSIDE
+﻿# INSIDE
 ## About the function
 Returns a logical time series by testing an expression towards an upper and a
 lower limit.

--- a/docs/mesh/calculations/functions/integer.md
+++ b/docs/mesh/calculations/functions/integer.md
@@ -1,4 +1,4 @@
-## INTEGER
+# INTEGER
 ## About the function
 Converts a number in a time series to an integer by cutting all decimals.
 
@@ -11,7 +11,7 @@ The function can also be applied to a single number.
 - INTEGER(t)
 - INTEGER(d)
 
-**Description**
+## Description
 
 | # | Type | Description |
 |---|---|---|

--- a/docs/mesh/calculations/functions/isvalid.md
+++ b/docs/mesh/calculations/functions/isvalid.md
@@ -1,6 +1,6 @@
-## IsValid
+# IsValid
 
-### About the function
+## About the function
 
 A time series reference specified by **@t(‘TheReference’)** may give no result.
 The reason for this may be one of the following:
@@ -14,13 +14,15 @@ for a given object.
 
 You may use either IsValid or [Valid](../functions/valid.md) to handle these cases.
 
-### Syntax
+## Syntax
 
 - IsValid(t)
 - IsValid(s,s)
 - IsValid(T)
 
-**Description**
+## IsValid(t)
+
+### Description
 
 | Type | Description |
 |---|---|
@@ -28,7 +30,9 @@ You may use either IsValid or [Valid](../functions/valid.md) to handle these cas
 
 The function returns 1 or 0 representing true or false.
 
-**Description**
+## IsValid(s,s)
+
+### Description
 
 | Type | Description |
 |---|---|
@@ -40,7 +44,9 @@ calculation context. If the target of the expected type is found, then the
 function returns 1 (representing true), otherwise the function returns 0. The
 function does not produce any log events when lookup fails.
 
-**Description**
+## IsValid(T)
+
+### Description
 
 | Type | Description |
 |---|---|
@@ -56,7 +62,7 @@ type have a time series attributes `Income` and `Production`. The `Income` attri
 
 The `HydroPlant` objects below Lyse do not have any physical time series attached to the `Production` attribute, but those below Sauda have.
 
-**Case 1**
+#### Example 1
 - The expression on a `Watercourse` attribute is like this
 - `## = @IsValid(@T('has_HydroPlant.Income'))`
 
@@ -66,7 +72,7 @@ The `HydroPlant` objects below Lyse do not have any physical time series attache
 
 The result shows that the calculation returns 1 (true) for both Lyse and Sauda.
 
-**Case 2**
+#### Example 2
 - The expression on a `Watercourse` attribute is like this
 - `## = @IsValid(@T('has_HydroPlant.Production'))`
 

--- a/docs/mesh/calculations/functions/linear.md
+++ b/docs/mesh/calculations/functions/linear.md
@@ -1,11 +1,11 @@
-﻿## Linear
+﻿# Linear
 
-### About the function
+## About the function
 
 Sets the curve type of argument series to piecewise linear or staircase start of
 step.
 
-### Syntax
+## Syntax
 
 - Linear(t,s)
 

--- a/docs/mesh/calculations/functions/ln.md
+++ b/docs/mesh/calculations/functions/ln.md
@@ -21,8 +21,8 @@ function returns an empty value.
 | 1 | t | Time series |
 | 1 | d | Number |
 
-## Example
-Example 1: LN(t)
+## Examples
+### Example 1: LN(t)
 
 ```
 Temperature_hour_VV = @LN(@t('Temperature_hour_raw'))
@@ -30,7 +30,7 @@ Temperature_hour_VV = @LN(@t('Temperature_hour_raw'))
 
 ![](assets/images/ex_LN-nimbusexample1.png)
 
-Example 2: LN(d)
+### Example 2: LN(d)
 
 ```
 ResultTs = @LN(1)

--- a/docs/mesh/calculations/functions/log.md
+++ b/docs/mesh/calculations/functions/log.md
@@ -11,7 +11,7 @@ exponent c, which the base number must be raised with to get the number x.
 The input value must be a positive number larger than 0. If not, the function
 returns an empty value.
 
-**S****yntax**
+## Syntax
 
 - LOG(t|d)
 
@@ -20,12 +20,12 @@ returns an empty value.
 | 1 | t | Time series |
 | 1 | d | Number |
 
-## Example
-Example 1: @LOG(t)
+## Examples
+### Example 1: @LOG(t)
 
 `Temperature_hour_VV = @LOG(@t('Temperature_hour_raw'))`
 
-Example 2: @LOG(d)
+### Example 2: @LOG(d)
 
 `ResultTs = @LOG(1)`
 

--- a/docs/mesh/calculations/functions/max.md
+++ b/docs/mesh/calculations/functions/max.md
@@ -1,6 +1,6 @@
-﻿## MAX
+﻿# MAX
 
-### About the functions
+## About the function
 
 Finds the highest values in time series, numbers, arrays or combinations of
 these.
@@ -10,7 +10,7 @@ but most of them returns a time series.
 
 The result series has the same resolution as the input time series. This also applies to cases where there are multiple time series involved and they all have the same resolution. If there are series with different resolutions, the result is a breakpoint series.
 
-### Syntax
+## Syntax
 
 - MAX(T)
 - MAX(D) -> returns a number
@@ -22,7 +22,7 @@ The result series has the same resolution as the input time series. This also ap
 - MAX(d,d) -> returns a number
 - MAX(T,T)
 
-### Description
+## Description
 
 | # | Type | Description |
 |---|---|---|

--- a/docs/mesh/calculations/functions/mean.md
+++ b/docs/mesh/calculations/functions/mean.md
@@ -1,6 +1,6 @@
-## MEAN
+# MEAN
 
-### About the function
+## About the function
 
   Takes the average value of time series, arrays and number series.
 
@@ -8,13 +8,13 @@
   the result series will have this resolution. If there are different resolutions involved, 
   the result time series will be a breakpoint series.
 
-### Syntax
+## Syntax
 
 - MEAN(t)  -> returns a number
 - MEAN(T)
 - MEAN(D)  -> returns a number
 
-### Description
+## Description
 
 
 | # | Type | Description |
@@ -25,7 +25,7 @@
 
 ## Examples
 
-  Example 1: @MEAN(t)
+### Example 1: @MEAN(t)
 
   `TempPercentiles = @MEAN(@t('Temperature_hour_raw'))`
 
@@ -40,7 +40,7 @@ requested time period, you can use the
 [PushExtPeriod](../functions/push_ext_period.md)/[PopExtPeriod](../functions/pop_ext_period.md) function
 to explicitly define the input period to the function.
 
-  Example 2: @MEAN(T)
+### Example 2: @MEAN(T)
 
   `Temperature_hour_operative = @MEAN(@T('Temperature_hour'))`
 
@@ -51,7 +51,7 @@ time series in the array for every time step.
 
   ![](assets/images/ex_MEAN-nimbustable2.png)
 
-  Example 3: @MEAN(D)
+### Example 3: @MEAN(D)
 
   Res = @MEAN(1,5,8,2.5,11)
 

--- a/docs/mesh/calculations/functions/meshid.md
+++ b/docs/mesh/calculations/functions/meshid.md
@@ -1,15 +1,17 @@
-﻿## MeshID
+﻿# MeshID
+
+## About the function
 
 This function is used to get an identification of the Mesh object having a
 calculated time series where this function is used. It is also possible to get
 the identification from a related Mesh object by giving a search or navigation
 suffix to the function argument.
 
-### Syntax
+## Syntax
 
 - MeshID(s)
 
-**Description**
+## Description
 
 | Type | Description |
 |---|---|

--- a/docs/mesh/calculations/functions/min.md
+++ b/docs/mesh/calculations/functions/min.md
@@ -1,6 +1,6 @@
-﻿## MIN
+﻿# MIN
 
-### About the function
+## About the function
 
 Finds the lowest values in time series, numbers, arrays or combinations of
 these.
@@ -23,7 +23,7 @@ The result series has the same resolution as the input time series. This also ap
 - MIN(d,d)  -> returns a number
 - MIN(T,T)
 
-### Description
+## Description
 
 | # | Type | Description |
 |---|---|---|
@@ -32,9 +32,9 @@ The result series has the same resolution as the input time series. This also ap
 
 There are similar functions to find highest values, see [function MAX](max.md)
 
-### Examples
+## Examples
 
-#### Example 1: @MIN(T)
+### Example 1: @MIN(T)
 
 `Temperature_hour_operative = @MIN(@T('.Temperature_hour'))`
 
@@ -45,7 +45,7 @@ e.g.:
 
 ![](assets/images/ex_MIN-nimbustable.png)
 
-#### Example 2: @MIN(D)
+### Example 2: @MIN(D)
 
 Result = @MIN({1, 5, 8, 2.5, 11})
 
@@ -53,7 +53,7 @@ Result = 1
 
 Result returns the lowest value from the array of numbers.
 
-#### Example 3: @MIN(t)
+### Example 3: @MIN(t)
 
 Returns the lowest values from the time series for the requested period.
 
@@ -71,7 +71,7 @@ calculation the result values are divided on -5.
 From the requested period, we can see that the minimum value is -5. Used in
 calculation the result values are added by -5.
 
-#### Example 4: @MIN(t,t)
+### Example 4: @MIN(t,t)
 
 `Temperature_hour_operative = @MIN(@t('.Temperature_hour_raw'),@t('.TempManualCorrection'))`
 
@@ -80,7 +80,7 @@ series 2.
 
 ![](assets/images/ex_MIN-nimbustable4.png)
 
-#### Example 5: @MIN(T,t)
+### Example 5: @MIN(T,t)
 
 `Temperature_hour_operative = @MIN(@T('.Temperature_hour'),@t('.TempManualCorrection'))`
 
@@ -92,7 +92,7 @@ series for each time step, e.g.:
 
 ![](assets/images/ex_MIN-nimbustable5.png)
 
-#### Example 6: @MIN(t,d)
+### Example 6: @MIN(t,d)
 
 `Result = @MIN(@t('Temperature_hour_raw'),-0.5)`
 
@@ -101,7 +101,7 @@ step, e.g.:
 
 ![](assets/images/ex_MIN-nimbustable6.png)
 
-#### Example 7: @MIN(d,d)
+### Example 7: @MIN(d,d)
 
 `Result = @MIN(8,2.5)`
 

--- a/docs/mesh/calculations/functions/mix.md
+++ b/docs/mesh/calculations/functions/mix.md
@@ -14,7 +14,9 @@ The different variations of this function are described below. For MIX(t,T) and
 MIX(t,T,t), see [MIX by selecting from time series
 array](../functions/mix_by_selecting_from_time_series_array.md).
 
-Description MIX(t,t) and MIX(t,t,s)
+## MIX(t,t) and MIX(t,t,s)
+
+### Description
 
 | # | Type | Description |
 |---|---|---|
@@ -30,7 +32,7 @@ Description MIX(t,t) and MIX(t,t,s)
 | MERGE_ADD | Retrieves value from the second time series if this is a real value (not NaN). |
 | MERGE_POINTS | As the MERGE version, but checks whether there is a point value for the point of time on the first time series. If no, the value from the second time series is used on this point of time. Will only have the intended effect if you have a breakpoint series. |
 
-## Example
+### Example
 @MIX(t,t)
 
 ```
@@ -43,7 +45,9 @@ shown in the table.
 
 ![](assets/images/ex_MIX-nimbustable.png)
 
-Description MIX(t,t,t)
+## MIX(t,t,t)
+
+### Description
 
 | # | Type | Description |
 |---|---|---|
@@ -51,7 +55,7 @@ Description MIX(t,t,t)
 | 2 | t | The function gets its values from this time series if the first argument returns TRUE. |
 | 3 | t | Optional. The function gets its values from this time series if the first argument returns FALSE. |
 
-## Example
+### Example
 @MIX(t,t,t)
 
 ```

--- a/docs/mesh/calculations/functions/mix0.md
+++ b/docs/mesh/calculations/functions/mix0.md
@@ -11,8 +11,8 @@ are missing, the result value is also missing.
 
 The time series are fixed interval series, i.e. hour, day, week, etc.
 
-## Example
-Example 1: @MIX0(t,t)
+## Examples
+### Example 1: @MIX0(t,t)
 
 Given two objects called `NO1` and `NO2` with a time series attribute
 called `Income`, we can have the following:
@@ -26,7 +26,7 @@ income2 = @t('../*[.Name=NO2].Income')
 
 ![](assets/images/ex_MIX0-Nimbustable1.png)
 
-Example 2: @MIX0(T)
+### Example 2: @MIX0(T)
 
 Here we have an array holding three `Income` time series:
 

--- a/docs/mesh/calculations/functions/mix_by_selecting_from_time_series_array.md
+++ b/docs/mesh/calculations/functions/mix_by_selecting_from_time_series_array.md
@@ -1,5 +1,5 @@
 ﻿# MIX by selecting from time series array
-About this function
+## About the function
 
 MIX is a function that calculates result series by mixing contribution from a
 set of input time series. A typical usage is to handle multiple 'if-elseif-else’
@@ -24,8 +24,8 @@ the result series is defined like this:
 - Default series not defined: The result series has the same resolution as the highest resolution found. The result values are copied from first series in array for periods when contribution index found in argument 1 series is 1, from second series when contribution index is 2 etc.
 - Default series defined: If contribution index is out of range, the corresponding result values are retrieved from default series.
 
-## Example
-Example 1: @MIX(t,T)
+## Examples
+### Example 1: @MIX(t,T)
 
 `Temperature_hour_operative = @MIX(@t('TempManualCorrection'),@T('Temperature_hour'))`
 
@@ -36,7 +36,7 @@ table.
 
 ![](assets/images/ex_MIXbe-Nimbustable.png)
 
-Example 2: @MIX(t,T,t)
+### Example 2: @MIX(t,T,t)
 
 `Temperature_hour_operative = @MIX(@t('TempManualCorrection'),@T('Temperature_hour'),@t('TempPercentiles'))`
 
@@ -46,7 +46,7 @@ of the table.
 
 ![](assets/images/ex_MIXbe-Nimbustable2.png)
 
-Example 3: @MIX(t,T,t)
+### Example 3: @MIX(t,T,t)
 
 `## = @MIX(@t('TsSelector'),{@t('Ts1'),@t('Ts2'),@t('Ts1')*2.3,@t('Ts1')+@t('Ts2')},@t('TsDefault'))`
 

--- a/docs/mesh/calculations/functions/negative.md
+++ b/docs/mesh/calculations/functions/negative.md
@@ -1,4 +1,4 @@
-﻿## NEGATIVE
+﻿# NEGATIVE
 ## About the function
 Picks the negative values from a time series. Zero is considered to be a
 positive number.

--- a/docs/mesh/calculations/functions/normal.md
+++ b/docs/mesh/calculations/functions/normal.md
@@ -1,5 +1,5 @@
 ﻿# Normal
-**About the function**
+## About the function
 
 Calculates various normal series for input series with respect to a defined
 history period given as from and until year.
@@ -18,6 +18,6 @@ history period given as from and until year.
 | 5 | s | The smoothing method to apply prior to calculating the normal.<br/> Available types are:<br/> NONE, AVERAGE, MEDIAN, GAUSS, MEDIAN_GAUSS<br/>Implicitly applies the corresponding TS_GLIDING_* function. | AVERAGE |
 | 6 | d | Size of the smoothing value window.<br/>Zero means no smoothing. Must be an odd number. If input is an even number greater than 0, it is incremented by one. |   |
 
-**Example syntax**
+## Example
 
 `Normal_temperature = @Normal(@t('Temperature_hour_operative'),2000,2013,'Max','MEDIAN_GAUSS',3)`

--- a/docs/mesh/calculations/functions/outside.md
+++ b/docs/mesh/calculations/functions/outside.md
@@ -1,4 +1,4 @@
-## OUTSIDE
+# OUTSIDE
 ## About the function
 Returns a logical time series by testing an expression towards an upper and a
 lower limit.
@@ -18,8 +18,8 @@ The result series has the same resolution as the input time series.
 | 3 | d or t | Numerical value, upper limit or Time series of numerical values, upper limit. |
 | 4 | s | Optional. Default value (no code): min > expression or expression > max 'LOHI': min >= expression or expression >= max 'LOW': min >= expression or expression > max 'HIGH': min > expression or expression >= max |
 
-## Example
-Example 1: @OUTSIDE(d,t,d)
+## Examples
+### Example 1: @OUTSIDE(d,t,d)
 
 ```
 Temperature_hour_VV = @OUTSIDE(0, @t('Temperature_hour_raw'), 12)
@@ -29,7 +29,7 @@ Values in @t('Temperature_hour_raw') 12 are evaluated to true (1). Other values
 and NaN are evaluated to false (0). Here values on both the lower limit 0 and
 upper limit 12 are evaluated to false.
 
-Example 2: @OUTSIDE(d,t,d,s)
+### Example 2: @OUTSIDE(d,t,d,s)
 
 ```
 Temperature_hour_VV = @OUTSIDE(0, @t('Temperature_hour_raw'), 12, 'LOHI')

--- a/docs/mesh/calculations/functions/parameter.md
+++ b/docs/mesh/calculations/functions/parameter.md
@@ -1,5 +1,5 @@
-﻿## Parameter
+﻿# Parameter
 
-### About the function
+## About the function
 
 This function is no longer available in Mesh.

--- a/docs/mesh/calculations/functions/pdlog.md
+++ b/docs/mesh/calculations/functions/pdlog.md
@@ -1,16 +1,16 @@
-## PDLOG
+# PDLOG
 
-### About this function
+## About the function
 
 The PDLOG function is used to give messages to SmG Event Log based on events
 occurring in SmG Calculator.
 
-### Syntax
+## Syntax
 
 - PDLOG(d,s[,t])
 - PDLOG(d,s,t,d)
-  
-**Description**
+
+## Description
 
 | # | Type | Description |
 |---|---|---|
@@ -20,6 +20,8 @@ occurring in SmG Calculator.
 | 4 | d | Number of values to be written to Event Log from the time series. |
 
 
+
+## Examples
 
 ### Example 1
 ```

--- a/docs/mesh/calculations/functions/percentile.md
+++ b/docs/mesh/calculations/functions/percentile.md
@@ -1,16 +1,18 @@
-﻿## PERCENTILE
-**About the function**
+﻿# PERCENTILE
+## About the function
 
 Calculates percentiles based on one time series or an array of time series.
 
-Syntax1
+## PERCENTILE(t,d,d,d[,s,[,s]])
+
+### Syntax
 
 - PERCENTILE(t,d,d,d[,s,[,s]])
 
 It takes one series as argument and history from year and to year as second and
 third argument.
 
-## Description
+### Description
 
 | # | Type | Description | Example |
 |---|---|---|---|
@@ -21,7 +23,7 @@ third argument.
 | 5 | s | Optional parameter.<br/> Method specification.<br/>Possible values are BY_SUM or SCALED_MEAN_BY_SUM.<br/>[See description below](#methods). |   |
 | 6 | s | Period definition for the function.<br/> Note! Remember + before the first element, comma as separator and period length without +. | '+3d' Three days after the end time. <br/>'-3d' Three days before the starting time. <br/>'+3d,5d' Three days after the starting time with a period length of five days. |
 
-Example 1
+### Example 1
 
 `## = @PERCENTILE (@t('Temperature_hour_operative'),2000,2010,100)`
 
@@ -43,11 +45,15 @@ P100. The result takes the P50 values for each time step from year 2000 to year
 If we ask for the 75% percentile, the function interpolates between the values
 for P70 and P80.
 
-Syntax2
+## PERCENTILE(T,d[,s[,s]])
+
+### Syntax
 
 PERCENTILE(T,d[,s[,s]])
 
 It takes an array of time series as an argument.
+
+### Description
 
 | Type | Description | Example |
 |---|---|---|
@@ -56,7 +62,7 @@ It takes an array of time series as an argument.
 | s | Optional parameter. Method specification. Possible values are BY_SUM, SCALED_MEAN_BY_SUM or SCALED_BY_SUM. [See description below](#methods). |   |
 | s | Period definition for the function. Note! Remember + before the first element, comma as separator and period length without +. | '+3d' Three days after the end time. '-3d' Three days before the starting time. '+3d,5d' Three days after the starting time with a period length of five days. |
 
-Example 2
+### Example 2
 
 `## = @PERCENTILE(@T('AreaTemperature'),100,'BY_SUM')`
 
@@ -65,7 +71,7 @@ requested period, i.e. Ensemble03 (P100).
 
 ![](assets/images/ex_percentile2.png)
 
-Example 3
+### Example 3
 
 `## = @PERCENTILE(@T('AreaTemperature'),100,'SCALED_MEAN_BY_SUM')`
 
@@ -75,7 +81,7 @@ SumMean/IndexTimeSeriesMean.
 
 ![](assets/images/ex_percentile3.png)
 
-Example 4
+### Example 4
 
 `## = @PERCENTILE(@T('AreaTemperature'),100,'SCALED_BY_SUM')`
 
@@ -85,7 +91,7 @@ percentile index P100, divided by the sum for the max value time series.
 
 ![](assets/images/ex_percentile4.png)
 
-### Methods
+## Methods
 
 Method BY_SUM:
 

--- a/docs/mesh/calculations/functions/positive.md
+++ b/docs/mesh/calculations/functions/positive.md
@@ -1,4 +1,4 @@
-﻿## POSITIVE
+﻿# POSITIVE
 ## About the function
 Picks the positive values from a time series. Zero is considered to be a
 positive number.

--- a/docs/mesh/calculations/functions/power.md
+++ b/docs/mesh/calculations/functions/power.md
@@ -1,4 +1,4 @@
-﻿## POWER
+﻿# POWER
 ## About the function
 Returns the result of a time series or number raised to a power. The function
 uses the equation `y=xn. x` and `n` can be a time series or a number.
@@ -17,8 +17,8 @@ The result series has the same resolution as the input time series.
 | 2 | d | Numerical value used for the exponential factor n in the equation. |
 | 2 | t | Time series used for the exponential factor n in the equation. |
 
-## Example
-Example 1: @POWER(t,d)
+## Examples
+### Example 1: @POWER(t,d)
 
 ```
 Waterlevel_hour_operative = @POWER(@t('Waterlevel_hour_raw'),2)
@@ -26,7 +26,7 @@ Waterlevel_hour_operative = @POWER(@t('Waterlevel_hour_raw'),2)
 
 ![](assets/images/ex_POWER-nimbustable1.png)
 
-Example 2: @POWER(d,t)
+### Example 2: @POWER(d,t)
 
 ```
 Waterlevel_hour_operative = @POWER(2,@t('Waterlevel_hour_raw'))
@@ -34,7 +34,7 @@ Waterlevel_hour_operative = @POWER(2,@t('Waterlevel_hour_raw'))
 
 ![](assets/images/ex_POWER-nimbustable2.png)
 
-Example 3: @POWER(t,t)
+### Example 3: @POWER(t,t)
 
 ```
 Waterlevel_hour_operative = @POWER(@t('Waterlevel_hour_raw'),@t('Waterlevel_hour_raw'),)
@@ -42,7 +42,7 @@ Waterlevel_hour_operative = @POWER(@t('Waterlevel_hour_raw'),@t('Waterlevel_hour
 
 ![](assets/images/ex_POWER-nimbustable3.png)
 
-Example 4: @POWER(d,d)
+### Example 4: @POWER(d,d)
 
 ```
 RS4 = @POWER(4,2)

--- a/docs/mesh/calculations/functions/profile.md
+++ b/docs/mesh/calculations/functions/profile.md
@@ -1,4 +1,4 @@
-﻿## PROFILE
+﻿# PROFILE
 This topic describes a PROFILE variant ([R12](#r12)) for transforming from one
 time resolution to another.
 
@@ -6,18 +6,18 @@ To get an overview of all the variants of the function, see:
 
 [Which functions can be used when?](../functions/transform_what_when.md)
 
-###### R12
-## About the function
+## R12
+### About the function
 PROFILE lets you create values on a series in periods where values do not exist
 based on the length of the input time series.
 
 The length of the profile series must be equal to a calendar unit, for example
 year.
 
-## Syntax
+### Syntax
 - PROFILE(t)
 
-## Description
+### Description
 
 | # | Type | Definition |
 |---|---|---|
@@ -31,7 +31,7 @@ necessary.
 The function returns a time series with the same resolution as the input series
 with values created by repetition of the values found on the input series.
 
-## Example
+### Example
 `@PROFILE(t)`
 
 `Result time series = @PROFILE(@t('TSPH'))`

--- a/docs/mesh/calculations/functions/profile_with_explicit_frequency.md
+++ b/docs/mesh/calculations/functions/profile_with_explicit_frequency.md
@@ -6,8 +6,8 @@ To get an overview of all the variants of the function, see:
 
 [Which functions can be used when?](../functions/transform_what_when.md)
 
-###### R13
-## About the function
+## R13
+### About the function
 This is a function that calculates a time series by doing repeating an input
 series segment to cover requested time period. Values found on input series are
 moved into requested calculation period on a calendar based manner, i.e. values
@@ -21,10 +21,10 @@ This function is closely related to [R12](../functions/profile.md#r12), which on
 one argument; the input time series. In this case the function derives a
 repetition frequency from physical value period found on source series.
 
-## Syntax
+### Syntax
 - PROFILE(t,s)
 
-**Description**
+### Description
 
 | # | Type | Definition |
 |---|---|---|
@@ -45,7 +45,7 @@ input series. If frequency indicates a span that is narrower than time span on
 input series, then values from first segment are repeated into requested time
 span.
 
-## Example
+### Example
 Some examples are cited below:
 
 Result1 = @PROFILE(@t(‘TsInputBrP’),'WEEK')

--- a/docs/mesh/calculations/functions/push_ext_period.md
+++ b/docs/mesh/calculations/functions/push_ext_period.md
@@ -35,7 +35,7 @@ in calculations are handled implicitly when using Mesh as a foundation.
 - PushExtPeriod(s,d,d)
 
 
-## **Description**
+## Description
 
 
 | # | Type | Description |

--- a/docs/mesh/calculations/functions/rating_curve.md
+++ b/docs/mesh/calculations/functions/rating_curve.md
@@ -1,5 +1,5 @@
 ﻿# RatingCurve
-**About the function**
+## About the function
 
 The function is used to lookup values from a complex rating curve description to
 convert water level measurements in rivers to discharge unit. The function
@@ -15,7 +15,7 @@ Q = ai (h+bi)^ci hi ≤ h i+1 hi+1 ≤ h n+2
 The description gives factors a, b and for different value segments i for
 elevation h. Each definition may be valid for a given time interval.
 
-**S**yntax
+## Syntax
 
 - RatingCurve(t)
 

--- a/docs/mesh/calculations/functions/reset_status.md
+++ b/docs/mesh/calculations/functions/reset_status.md
@@ -1,10 +1,10 @@
-## RESET_STATUS
+# RESET_STATUS
 ## About the function
 This function is used to make changes on the [status of time
 series](../functions/status.md). The result series has the same resolution as the input
 time series.
 
-  **Syntax**
+## Syntax
 
 - RESET_STATUS(t[,d|s])
 
@@ -73,14 +73,14 @@ information in Nimbus. Available correction methods are as follows:
 
 
 
-## Example
-  Example 1: @RESET_STATUS(t)
+## Examples
+### Example 1: @RESET_STATUS(t)
 
   ResultTs = @RESET_STATUS(@t(‘Ts1’))
 
   Zeroes out all status information for the time series.
 
-  Example 2: @RESET_STATUS(t,s)
+### Example 2: @RESET_STATUS(t,s)
 
   Temperature_hour_VEE = @RESET_STATUS(@t('Temperature_hour_VV'),'notok')
 

--- a/docs/mesh/calculations/functions/restriction.md
+++ b/docs/mesh/calculations/functions/restriction.md
@@ -1,5 +1,5 @@
 # Restriction
-### About the function
+## About the function
 This function generates a time series from the Restriction events associated
 with this element, filtered on Category and Status. The value at a given time
 will be chosen from the relevant event(s), using a strategy decided by the user.
@@ -13,11 +13,11 @@ see the help for the **Smart Power Apps** module **Availability Planner**.**
 series, unless an explicit transformation to a fixed interval is specified in
 the time series calculation.
 
-### Syntax
+## Syntax
 - Restriction(s, s, [d/t], s, (s))
 
 
-### Description
+## Description
 
 
 | # | Type | Description |
@@ -29,7 +29,7 @@ the time series calculation.
 | 5 | s | (Optional) Search string to an object in ' '. Must return exactly one object. The time series will be generated based on the Restriction events related to this object. |
 
 
-Merge functions
+### Merge functions
 
 | Function | Description |
 |---|---|
@@ -40,7 +40,7 @@ Merge functions
 | Sum | Sums the values of all the active events. |
 | Average | Finds the average value of all the active events. |
 
-### Examples
+## Examples
 ```@Restriction('DischargeMin[m3/s]', 'Licensed', @d('.DischargeDefault'),'Maximum')`
 
 Finds events with Category = 'DischargeMin[m3/s]', and Status = 'Licensed'. Uses
@@ -65,14 +65,14 @@ events, the value found in the attribute '.DischargeDefault' is used.
 ***Note!*** The events are found on the object using the link relations
 to_HydroPlant.
 
-### Possible statuses
+## Possible statuses
   This is a list of the possible statuses that can be used:
 
 - Licensed (used as the main restriction)
 - SelfImposed (used as the exception of the main restriction)
 
 
-### Possible categories
+## Possible categories
   This is a list of the possible categories:
 
 - DischargeMin[m3/s]

--- a/docs/mesh/calculations/functions/revision.md
+++ b/docs/mesh/calculations/functions/revision.md
@@ -1,6 +1,6 @@
-## Revision
+# Revision
 
-### About the function
+## About the function
 
 This function generates a time series from the Revision events associated with
 this element, filtered on Status. The value will be 1 at the times where there
@@ -14,12 +14,12 @@ series, unless an explicit transformation to a fixed interval is specified in
 the time series calculation.
 
 
-### Syntax
+## Syntax
 
 - Revision(s)
 - Revision(ss)
 
-### Description
+## Description
 
 | # | Type | Description |
 |---|---|---|
@@ -28,7 +28,7 @@ the time series calculation.
 
 
 
-### Examples
+## Examples
 
 `@Revision('Proposed')` generates a timeseries based on the Revision events with
 status 'Proposed'.
@@ -43,7 +43,7 @@ associated with this element.
 the Revision events on the parent object, which has Status 'Proposed' or
 'Recommended'.
 
-### Possible statuses
+## Possible statuses
   This is a list of the possible statuses that can be used:
 
 - Proposed

--- a/docs/mesh/calculations/functions/round.md
+++ b/docs/mesh/calculations/functions/round.md
@@ -1,4 +1,4 @@
-## ROUND
+# ROUND
 ## About the function
 Rounds the numbers of a time series. To make rounding to for instance two
 decimals, you must multiply with 100, do ROUND operation and then divide by 100.
@@ -15,7 +15,7 @@ The function can also be applied to a single number.
 - ROUND(d)
 
 
-**Description**
+## Description
 
 | # | Type | Description |
 |---|---|---|

--- a/docs/mesh/calculations/functions/round_integer.md
+++ b/docs/mesh/calculations/functions/round_integer.md
@@ -11,7 +11,7 @@ The function can also be applied to a single number.
 - ROUND_INTEGER(t)
 - ROUND_INTEGER(d)
 
-**Description**
+## Description
 
 | # | Type | Description |
 |---|---|---|

--- a/docs/mesh/calculations/functions/set_ts_val_unit.md
+++ b/docs/mesh/calculations/functions/set_ts_val_unit.md
@@ -1,16 +1,16 @@
-﻿## SET_TS_VALUNIT
+﻿# SET_TS_VALUNIT
 
-### About the function
+## About the function
 This function is used to change the unit of a time series. Especially calculated
 series may contain several multiplied time series and result in different unit
 than the input time series.
 
-### Syntax
+## Syntax
 
 - SET_TS_VALUNIT(t,d)
 - SET_TS_VALUNIT(t,s)
 
-### Description
+## Description
 
 | # | Type | Description |
 |---|---|---|
@@ -25,15 +25,15 @@ check if you are using the correct language for the code.
 **Note!** The value unit may affect the default transformation method that is used 
 when the series is requested in another resolution.
 
-### Examples
+## Examples
 
-Example 1: @SET_TS_VALUNIT(t,d)
+### Example 1: @SET_TS_VALUNIT(t,d)
 
 To change the unit of a result series to meters/second, the unit code is 120:
 
 @SET_TS_VALUNIT(timeseries1,120)
 
-Example 2: @SET_TS_VALUNIT(t,s)
+### Example 2: @SET_TS_VALUNIT(t,s)
 
 To change the unit of a result series to meters/second using text:
 

--- a/docs/mesh/calculations/functions/size.md
+++ b/docs/mesh/calculations/functions/size.md
@@ -1,22 +1,22 @@
-﻿## Size
+﻿# Size
 
-### About the function
+## About the function
 
 This function returns the number of elements in the array given as argument.
 
-### Syntax
+## Syntax
 
 - Size(T)
 - Size(D)
 - Size(S)
 
-### Description
+## Description
 
 | Type | Description |
 |---|---|
 | T or D or S | Array of time series or array of numeric values or array of string (symbols). |
 
-### Examples
+## Examples
 
 `Result = @Size({4,2,7,8})`
 

--- a/docs/mesh/calculations/functions/status_count.md
+++ b/docs/mesh/calculations/functions/status_count.md
@@ -1,5 +1,5 @@
-## STATUS_COUNT
-### About this function
+# STATUS_COUNT
+## About the function
 The STATUS_COUNT function takes one or more time series and returns a count of
 the number of points which match a given criterion ([status](../functions/status.md)).
 E.g. it can be used to count the number of 'missing' or 'notok' values. If one
@@ -9,19 +9,21 @@ point in time and make a time series out of those.
 
   The time series must have the same resolution.
 
-#### Example 1
+## Examples
+
+### Example 1
 `NumberOfMissingOrManualPoints = @STATUS_COUNT(@t('.Temperature_hour_raw'), 'missing|MANUAL')`
 
 Which will return the number of points in `Temperature_hour_raw` that are
 flagged as missing or manual.
 
-#### Example 2
+### Example 2
 `NotOkPoints = @STATUS_COUNT({@t('.Timeseries1'), @t('.Timeseries2'), @t('.Timeseries3')}, 'notok')`
 
 This will return a time series where each time series point is the number of
 points in Timeseries1/2/3 which are flagged as not OK at that time.
 
-### Syntax
+## Syntax
 - STATUS_COUNT(T,s)
 - STATUS_COUNT(t,s)
 
@@ -32,7 +34,7 @@ The second argument uses the same syntax as the logical argument in
 ## Description
 
 
-| # | Type | ## Description |
+| # | Type | Description |
 |---|---|---|
 | 1 | T | Array of time series. |
 | 2 | s | Symbol. |
@@ -40,7 +42,7 @@ The second argument uses the same syntax as the logical argument in
 
 
 
-| # | Type | ## Description |
+| # | Type | Description |
 |---|---|---|
 | 1 | t | Reference to a time series. |
 | 2 | s | Symbol. |

--- a/docs/mesh/calculations/functions/status_mask.md
+++ b/docs/mesh/calculations/functions/status_mask.md
@@ -1,9 +1,9 @@
-## STATUS_MASK
+# STATUS_MASK
 ## About the function
 Makes it possible to execute operations on time series based on the [status
 code](../functions/status.md) associated with the values.
 
-  **Syntax**
+## Syntax
 
 - STATUS_MASK(t,s,s)
 

--- a/docs/mesh/calculations/functions/sum.md
+++ b/docs/mesh/calculations/functions/sum.md
@@ -13,7 +13,7 @@ of the series in an array of time series.
 |---|---|---|
 | 1 | t or T | Source time series to create sum from. Array of time series to create sum from. |
 
-## Example
+## Examples
 ### Example 1: @SUM(t)
 
 Result = @SUM(@t(’Ts1’))

--- a/docs/mesh/calculations/functions/tan.md
+++ b/docs/mesh/calculations/functions/tan.md
@@ -1,4 +1,4 @@
-﻿## TAN
+﻿# TAN
 ## About the function
 This function is used to calculate the tangent of a time series. **Note!** The
 values of the input are in radians.

--- a/docs/mesh/calculations/functions/time.md
+++ b/docs/mesh/calculations/functions/time.md
@@ -26,7 +26,7 @@ also be used as argument to functions accepting a time point as number.
 You can convert a time point back to a time specification string by using the
 [TimeToString](../functions/time_to_string.md) function.
 
-Example using both Time and TimeSpan functions
+## Example using both Time and TimeSpan functions
 
 ``` 
 TimeWindow = @TimeSpan('HOUR') * @d('GlidingInterval')

--- a/docs/mesh/calculations/functions/time_delayed.md
+++ b/docs/mesh/calculations/functions/time_delayed.md
@@ -1,6 +1,6 @@
-## TimeDelayed
+# TimeDelayed
 
-### About this function
+## About the function
 
 This function uses an [XY set](../../concepts/modelling/xy-sets.md) to calculate a time-delayed output based on an input time series. A typical use case is simulating how water discharge at one point arrives downstream over time: a sudden increase in flow does not appear instantly at the output; instead, it spreads out over several time steps, with some fractions arriving early and the rest arriving progressively later.
 
@@ -8,7 +8,7 @@ The function takes each value in the input time series and distributes it forwar
 
 **_Note!_** The distribution preserves the total volume; i.e. volume in equals volume out. When several input values contribute to the same output time step, their delayed contributions are summed, which can produce transient peaks or dips in the output (e.g., when a fast-flow "front" catches up with the tail of an earlier slow-flow period).
 
-#### The XY set
+### The XY set
 
 | Axis | Meaning | Example (water flow) |
 |------|---------|----------------------|
@@ -16,7 +16,7 @@ The function takes each value in the input time series and distributes it forwar
 | **Y** | The percentage of the input value that is contributed at the corresponding delay offset. | 50 means 50% of the input value arrives at that offset. |
 | **Z** | The input value threshold at which this XY curve applies (i.e. a "valid-from" level). | A flow rate of 20 m3/s. |
 
-#### How the calculation works
+### How the calculation works
 
 For each time step `i` in the input series:
 
@@ -27,22 +27,22 @@ For each time step `i` in the input series:
 
 `NaN` values in the input are treated as 0 (they produce no delayed contribution).
 
-### Syntax
+## Syntax
 
 - TimeDelayed(t,s)
 
-### Description
+## Description
 
-| # | Type | ## Description |
+| # | Type | Description |
 |---|---|---|
 | 1 | t | Reference to a fixed-interval time series. Breakpoint series are not supported. |
 | 2 | s | Search specification targeting the XY set to use. |
 
-#### Example table
+### Example table
 
   ![](assets/images/TimeDelayed_Example.png)
 
-#### Example
+## Example
 
 Given an input value of exactly 20 at time `t` and an XY curve for the Z = 20 segment, the value is distributed as follows:
 
@@ -54,13 +54,13 @@ Given an input value of exactly 20 at time `t` and an XY curve for the Z = 20 se
 
 (The percentages sum to 100%, preserving total volume)
 
-#### Usage
+## Usage
 
 ```
 DelayedFlow = @TimeDelayed(@t('.FlowTimeSeries'), '.FlowDelayXySetAttributeName')
 ```
 
-#### Worked example with constant and changing flow
+## Worked example with constant and changing flow
 
 The table below shows the function applied to an hourly time series that has values of 20 for some time, then steps up to 30, and finally steps back down to 20.
 

--- a/docs/mesh/calculations/functions/time_mask.md
+++ b/docs/mesh/calculations/functions/time_mask.md
@@ -1,11 +1,11 @@
-## TIME_MASK
+# TIME_MASK
 
-### About the function
+## About the function
 
 This function creates time series from its arguments, normally used as time
 masks (a series with 1 or 0 as value), but not limited to only this type.
 
-### Syntax
+## Syntax
 
 There are two main categories of this function. The recommended variants:
 

--- a/docs/mesh/calculations/functions/tostring.md
+++ b/docs/mesh/calculations/functions/tostring.md
@@ -1,12 +1,12 @@
-﻿## ToString
+﻿# ToString
 
-### About the function
+## About the function
 
 This function translates a number to a string. It will not round the value, only
 truncate it. Optional argument describes number of decimals to include in the
 string.
 
-### Syntax
+## Syntax
 
 - ToString(d[,d])
 
@@ -17,7 +17,7 @@ string.
 | 1 | d | Numerical value that should be made into a string. |
 | 2 | d | Number of decimal places to include in the string representation. Default is 0. |
 
-### Examples
+## Examples
 
 Double attribute named 'Factor' has a numerical value 2.756.
 

--- a/docs/mesh/calculations/functions/trans_profile.md
+++ b/docs/mesh/calculations/functions/trans_profile.md
@@ -1,4 +1,4 @@
-﻿## TRANS_PROFILE
+﻿# TRANS_PROFILE
 This topic describes TRANS_PROFILE variants ([R8](#r8), [Ra8](#ra8), [R9](#r9),
 [Ra9](#ra9), [R10](#r10), [Ra10](#ra10), [R11](#r11), [Ra11](#ra11)) for
 transforming from one time resolution to another.
@@ -7,15 +7,15 @@ To get an overview of all the transformation function variants, see:
 
 [Transform group functions](../functions/transform.md)
 
-### R8
-## About the function
+## R8
+### About the function
 Converts a time series into a finer resolution. The function uses the SUM method
 as a basis for the distribution.
 
-## Syntax
+### Syntax
 - TRANS_PROFILE(t,t)
 
-## Description
+### Description
 
 | Type | Description |
 |---|---|
@@ -36,7 +36,7 @@ Pi = Profile value for the time point i in the result time series
 
 MI = Calculated mean value for the profile series for the distributed period
 
-## Example
+### Example
 `Profile = @TIME_MASK('HOUR',{'HOUR','HOUR+15x','HOUR+30x','HOUR+45x'},{1,2,3,2},'MIN15')`
 
 `Result time series = @TRANS_PROFILE(@t('Ts5'),Profile)`
@@ -47,15 +47,15 @@ for all the time points.
 
 ![](assets/images/ex_DISTRIBUTE-nimbustable6.png)
 
-### Ra8
-## About the function
+## Ra8
+### About the function
 Same as [R8](#r8), but with absolute handling of the profile. The profile can be
 scaled using a scaling factor, defined as first argument.
 
-## Syntax
+### Syntax
 - TRANS_PROFILE(d,t,t)
 
-## Description
+### Description
 
 | # | Type | Description |
 |---|---|---|
@@ -70,7 +70,7 @@ The distribution of the values is done like this:
 K is a scaling factor coming from argument 1 in the function. The other symbols
 used in the formula are the same as described in [R8](#r8).
 
-Example 1
+### Example 1
 
 `Profile = @TIME_MASK('HOUR',{'HOUR','HOUR+15x','HOUR+30x','HOUR+45x'},{1,2,3,2},'MIN15')`
 
@@ -82,7 +82,7 @@ true for all the time points.
 
 ![](assets/images/ex_TRANS_PROFILE-nimbustable.png)
 
-Example 2
+### Example 2
 
 `Profile = @TIME_MASK('HOUR',{'HOUR','HOUR+15x','HOUR+30x','HOUR+45x'},{1,2,3,2},'MIN15')`
 
@@ -92,15 +92,15 @@ Example 2
 @DISTRIBUTE(10,@t('Ts5'),MaskSeries,Profile) where the mask series argument is
 true for all the time points.
 
-### R9
-## About the function
+## R9
+### About the function
 Same as the function [R8](#r8), but with an extra argument deciding distribution
 method.
 
-## Syntax
+### Syntax
 - TRANS_PROFILE(t,t,s)
 
-## Description
+### Description
 
 | # | Type | Description |
 |---|---|---|
@@ -122,15 +122,15 @@ If the value on the input data series is 0, the value is calculated like this:
 
 Vi = Pi - MI
 
-### Ra9
-## About the function
+## Ra9
+### About the function
 Same as [R9](#r9), but with absolute handling of the profile. The profile can be
 scaled using a scaling factor, defined in argument 1.
 
-## Syntax
+### Syntax
 - TRANS_PROFILE(d,t,t,s)
 
-## Description
+### Description
 
 | # | Type | Description |
 |---|---|---|
@@ -146,14 +146,14 @@ The distribution of the values is done like this:
 K is a scaling factor coming from argument 1 in the function. The other symbols
 used in the formula are the same as described in [R9](#r9).
 
-### R10
-## About the function
+## R10
+### About the function
 Same as [R8](#r8) but uses a mask series in argument 3.
 
-## Syntax
+### Syntax
 - TRANS_PROFILE(t,t,t)
 
-## Description
+### Description
 
 | # | Type | Description |
 |---|---|---|
@@ -181,15 +181,15 @@ Vi= Pi- MI
 
 See also [R7](../functions/distribute.md#r7) that offers the same functionality.
 
-### Ra10
-## About the function
+## Ra10
+### About the function
 Same as [R10](#r10), but with absolute handling of profile. The profile can be
 scaled using a scaling factor defined in argument 1.
 
-## Syntax
+### Syntax
 - TRANS_PROFILE(d,t,t,t)
 
-## Description
+### Description
 
 | # | Type | Description |
 |---|---|---|
@@ -205,16 +205,16 @@ The distribution of the values is done like this:
 K is a scaling factor coming from argument 1 in the function. The other symbols
 used in the formula are the same as described in [R10](#r10).
 
-### R11
-## About the function
+## R11
+### About the function
 Same function as [R10](#r10), but with an extra argument deciding distribution
 method. Valid values are 'MEAN', 'AVERAGE' or 'SUM'. The last value gives the
 exact same result as [R10](#r10).
 
-## Syntax
+### Syntax
 - TRANS_PROFILE(t,t,t,s)
 
-## Description
+### Description
 
 | # | Type | Description |
 |---|---|---|
@@ -240,15 +240,15 @@ If the value on the input data series is 0, the value is calculated like this:
 
 Vi = Pi - MI
 
-### Ra11
-## About the function
+## Ra11
+### About the function
 Same as [R11](#r11), but with absolute handling of profile. The profile can be
 scaled using a scaling factor, defined in argument 1.
 
-## Syntax
+### Syntax
 - TRANS_PROFILE(d,t,t,t,s)
 
-## Description
+### Description
 
 | # | Type | Description |
 |---|---|---|

--- a/docs/mesh/calculations/functions/transform.md
+++ b/docs/mesh/calculations/functions/transform.md
@@ -72,6 +72,8 @@ If the input time series is time zone aware, we only allow `SUM` or `AVG`.
 
 ## TRANSFORM(t, s, s)
 
+### About the function
+
 This is the most common conversion function. You can use it to convert both
 ways, i.e. both from finer to coarser resolution, and the other way. The most
 common use is accumulation, i.e. transformation to coarser resolution. Most
@@ -86,17 +88,17 @@ transformation methods are available for this latter use.
 | 3 | s | Conversion method, see [accepted values](#transformation-methods). |
 
 
-### Example
+### Examples
 
-  Example 1: @TRANSFORM(t,s,s) Create week sums from a time series
+#### Example 1: @TRANSFORM(t,s,s) Create week sums from a time series
 
   Res1 = @TRANSFORM(@t('HourTs'), 'WEEK', 'SUM')
 
-  Example 2: @TRANSFORM(t,s,s) Create day average from a break point series
+#### Example 2: @TRANSFORM(t,s,s) Create day average from a break point series
 
   Res2 = @TRANSFORM(@t('BrpTs'), 'DAY', 'AVGI')
 
-  Example 3: Shows variants and their resulting time series
+#### Example 3: Shows variants and their resulting time series
 
   Input series:
 
@@ -131,6 +133,8 @@ transformation methods are available for this latter use.
 
 ## TRANSFORM(t, t, s)
 
+### About the function
+
 Conversion to periods given by points of time on the series given as argument 2.
 The result is a break point series. This function enables periods that are not
 standard calendar units, e.g. 3 hours, 10 days, etc.
@@ -158,6 +162,8 @@ this:
 
 ## TRANSFORM(t, d, s)
 
+### About the function
+
 Conversions given by the number given as argument 2. The number represents
 number of seconds in the period.
 
@@ -173,6 +179,8 @@ If d is defined as the value 864000 this means a period of 10 days
 (60*60*24*10). The result is a break point series.
 
 ## TRANSFORM(t, s, s, s)
+
+### About the function
 
 Corresponding functionality as in [`TRANSFORM(t, s, s)`](#transformt-s-s), but
 with an additional argument that decides which time zone that is the base for

--- a/docs/mesh/calculations/functions/transform_what_when.md
+++ b/docs/mesh/calculations/functions/transform_what_when.md
@@ -2,7 +2,7 @@
 
 Here is a list of common calculations where transformation of values from one resolution to another is included
 
-### ACCUMULATE VALUES STANDARD BEHAVIOR
+## ACCUMULATE VALUES STANDARD BEHAVIOR
 
 This means transforming from a break point series to a fixed interval series, or from a fixed interval series to a different fixed interval series with coarser resolution, for example from hour to day series.
 
@@ -10,7 +10,7 @@ For this type of task this is used:
 
 R1 = [@TRANSFORM(t,s,s)](../functions/transform.md#transformt-s-s)
 
-### ACCUMULATE VALUES TO SPECIFIC RESOLUTIONS
+## ACCUMULATE VALUES TO SPECIFIC RESOLUTIONS
 
 This means transformation from one time series to a different time series with a resolution that is not the same as calendar units, e.g. quarter, hour, day, week, month or year. You can choose a fixed period given from the start of the calculation or more general as points of time on a break point series.
 
@@ -21,7 +21,7 @@ R2 = [@TRANSFORM(t,t,s)](../functions/transform.md#transformt-t-s)
 
 R3 = [@TRANSFORM(t,d,s)](../functions/transform.md#transformt-d-s)
 
-### MAKE TRANSFORMATION WITH REFERENCE TO TIME ZONE
+## MAKE TRANSFORMATION WITH REFERENCE TO TIME ZONE
 
 The calculator performs calculations with reference to normal time if nothing else is given. A normal example is to accumulate hour values to day values or week values using local time (summer time) or a different time zone.
 
@@ -29,7 +29,7 @@ For this type of task the following is used:
 
 R4 = [@TRANSFORM(t,s,s,s)](../functions/transform.md#transformt-s-s-s)
 
-### DISTRIBUTING VALUES WITH REFERENCE TO PROFILE
+## DISTRIBUTING VALUES WITH REFERENCE TO PROFILE
 
 If you transform from fixed interval resolution to a finer resolution, e.g. from day to hour and want the calculated value to be distributed with reference to a profile, you cannot use standard transformation given from R1.
 

--- a/docs/mesh/calculations/functions/ts.md
+++ b/docs/mesh/calculations/functions/ts.md
@@ -1,23 +1,27 @@
-﻿## TS
+﻿# TS
 
-### About the function
+## About the function
 
 Creates a time series for further use in expressions.
 This function serves as a way to declare and initialise a time series.
 
-### Syntax
+## Syntax
 
 - TS(s[,d])
 - TS(s,s[,d])
 
-Description TS(s[,d])
+## TS(s[,d])
+
+### Description
 
 | # | Type | Description | Example |
 |---|---|---|---|
 | 1 | s | Unit. | 'VARINT', 'MIN15', 'HOUR' etc. |
 | 2 | d | Optional. Value. |   |
 
-Description TS(s,s[,d])
+## TS(s,s[,d])
+
+### Description
 
 | # | Type | Description | Example |
 |---|---|---|---|
@@ -27,7 +31,7 @@ Description TS(s,s[,d])
 
 The value is assigned to all points in time.
 
-## Example
+## Examples
 @TS(s)
 
 ` TS1 = @TS('VARINT')`

--- a/docs/mesh/calculations/functions/ts_acc_from.md
+++ b/docs/mesh/calculations/functions/ts_acc_from.md
@@ -20,7 +20,7 @@ point values to accumulated values.
 
 
 
-| # | Type | ## Description |
+| # | Type | Description |
 |---|---|---|
 | 1 | t | Result series y. The starting value of this series remains unchanged. |
 | 2 | t | Input series x. Contains values which are added to the previous value of the result series. |
@@ -38,8 +38,8 @@ assignment to the left side, as follows:
 @TS_ACC_FROM(##,%Ts,0,1,1)
 ```
 
-## Example
-### Example 1: @TS_ACC_FROM(t,t,d,d,d) 
+## Examples
+### Example 1: @TS_ACC_FROM(t,t,d,d,d)
 ```
 @TS_ACC_FROM(%'abo_t3',%'abo_t1',1,0,0)
 ```

--- a/docs/mesh/calculations/functions/ts_expand.md
+++ b/docs/mesh/calculations/functions/ts_expand.md
@@ -8,20 +8,24 @@ previous real value is used.
 - TS_EXPAND(t[,s])
 - TS_EXPAND(t,s[,s])
 
-## Description
+## TS_EXPAND(t[,s])
+
+### Description
 
 | # | Type | Description |
 |---|---|---|
 | 1 | t | Input time series with a fixed interval with potential missing values (defined as NaN values). |
 | 2 | s | Optional argument where you can specify curve type and potentially override the curve type definition on the input time series. The LINEAR value (case insensitive) gets linear behaviour on expansion. The STEP value, gets step behaviour on expansion. |
 
-Example 1: @TS_EXPAND(t)
+### Examples
+
+#### Example 1: @TS_EXPAND(t)
 
 `Temperature_hour_operative = @TS_EXPAND(@t('Temperature_hour_raw'))`
 
 ![](assets/images/ex_TS_EXPAND-nimbustable.png)
 
-Example 2: @TS_EXPAND(t,s)
+#### Example 2: @TS_EXPAND(t,s)
 
 `Temperature_hour_operative = @TS_EXPAND(@t('Temperature_hour_raw'),’step’)`
 
@@ -29,7 +33,9 @@ The original time series has a linear curve type.
 
 ![](assets/images/ex_TS_EXPAND-nimbustable2.png)
 
-Description TS_EXPAND(t,s,s)
+## TS_EXPAND(t,s,s)
+
+### Description
 
 | # | Type | Description |
 |---|---|---|

--- a/docs/mesh/calculations/functions/ts_gliding_average.md
+++ b/docs/mesh/calculations/functions/ts_gliding_average.md
@@ -1,4 +1,4 @@
-﻿## TS_GLIDING_AVERAGE
+﻿# TS_GLIDING_AVERAGE
 ## About the function
 Smooths out major fluctuations by taking average values from surrounding values.
 The amount by which the new values are smoothed out depends on the value of "d".

--- a/docs/mesh/calculations/functions/ts_gliding_gauss.md
+++ b/docs/mesh/calculations/functions/ts_gliding_gauss.md
@@ -1,4 +1,4 @@
-﻿## TS_GLIDING_GAUSS
+﻿# TS_GLIDING_GAUSS
 ## About the function
 The values of the time series are normally distributed, `d` determines the size
 of the time window.

--- a/docs/mesh/calculations/functions/ts_gliding_median.md
+++ b/docs/mesh/calculations/functions/ts_gliding_median.md
@@ -1,4 +1,4 @@
-﻿## TS_GLIDING_MEDIAN
+﻿# TS_GLIDING_MEDIAN
 ## About the function
 Returns a smoothed time series based on calculations of medians.
 

--- a/docs/mesh/calculations/functions/ts_gliding_median_gauss.md
+++ b/docs/mesh/calculations/functions/ts_gliding_median_gauss.md
@@ -1,4 +1,4 @@
-﻿## TS_GLIDING_MEDIAN_GAUSS
+﻿# TS_GLIDING_MEDIAN_GAUSS
 ## About the function
 This function first calculates the median and then normally distributes the
 median values. `d` determines the size of the time window.

--- a/docs/mesh/calculations/functions/ts_offset.md
+++ b/docs/mesh/calculations/functions/ts_offset.md
@@ -1,4 +1,4 @@
-## TS_OFFSET
+# TS_OFFSET
 ## About the function
 This function time-shifts a time series, i.e. uses values from a period which is
 different from the current calculation period.
@@ -36,9 +36,9 @@ The table below shows the valid offset unit codes.
 | YEAR |
 
 
-  **Example**
+## Examples
 
-  Example 1: @TS_OFFSET(t,d)
+### Example 1: @TS_OFFSET(t,d)
 
   `CompareTemp = @TS_OFFSET(@t('AreaTemperature'),-2)`
 
@@ -48,7 +48,7 @@ moves backwards in time for negative numbers.
 
   ![](assets/images/ex_TS_OFFSET-nimbustable.png)
 
-  Example 2: @TS_OFFSET(t,d)
+### Example 2: @TS_OFFSET(t,d)
 
   `CompareTemp = @TS_OFFSET(@t('AreaTemperature'),3)`
 

--- a/docs/mesh/calculations/functions/tsiqfill.md
+++ b/docs/mesh/calculations/functions/tsiqfill.md
@@ -1,4 +1,4 @@
-﻿## TS_IQ-FILL
+﻿# TS_IQ-FILL
 ## About the function
 Places logical values in any empty fields in a time series by taking the average
 of the previous and following values in the time series.
@@ -22,15 +22,15 @@ from value at time [t] til time [t+1].
 If the first cell(s) is empty, the next value is copied. If the last cell(s) is
 empty, the previous values is copied.
 
-## Example
-Example 1: @TS_IQ_FILL(t) step
+## Examples
+### Example 1: @TS_IQ_FILL(t) step
 
 Result = @TS_IQ_FILL(%'TS10S')
 
 Finds the first value in the first row. The value 5,00 is filled into the empty
 space preceding the next value, 10,00. See table.
 
-Example 2: @TS_IQ_FILL(t) linear
+### Example 2: @TS_IQ_FILL(t) linear
 
 Result = @TS_IQ_FILL(%'TS10L')
 

--- a/docs/mesh/calculations/functions/valid.md
+++ b/docs/mesh/calculations/functions/valid.md
@@ -1,6 +1,6 @@
-﻿## Valid
+﻿# Valid
 
-### About the function
+## About the function
 
 A time series reference specified by **@t(‘TheReference’)** may give no result.
 The reason for this may be one of the following:
@@ -13,11 +13,11 @@ tells the user it did not manage to resolve **TheReference** for a given object.
 
 See also function [IsValid](../functions/isvalid.md).
 
-### Syntax
+## Syntax
 
 - Valid(T)
 
-### Description
+## Description
 
 | Type | Description |
 |---|---|
@@ -25,7 +25,7 @@ See also function [IsValid](../functions/isvalid.md).
 
 The function returns an array of valid time series.
 
-## Examples
+## Example
 
 Precondition:
 

--- a/docs/mesh/calculations/functions/validate_abs_limit.md
+++ b/docs/mesh/calculations/functions/validate_abs_limit.md
@@ -1,12 +1,12 @@
-﻿## ValidateAbsLimit
-**About the function**
+﻿# ValidateAbsLimit
+## About the function
 
 Validates time series using absolute limits. Values outside the specified
 limits, are marked with **!** (Not Ok). Values with control towards upper or
 lower limit are set to validated and marked with **V01**, meaning validation
 method 1. You can see this code if you turn on value information in Nimbus.
 
-**Syntax**
+## Syntax
 
 - ValidateAbsLimit(t,t|d,t|d)
 
@@ -18,7 +18,9 @@ method 1. You can see this code if you turn on value information in Nimbus.
 | 2 | t d | Time series for lower limit. Numerical value for lower limit. |
 | 3 | t d | Time series for upper limit. Numerical value for lower limit. |
 
-**Example 1**
+## Examples
+
+### Example 1
 ```
 Waterlevel_hour_VEE = @ValidateAbsLimit(@t('Waterlevel_hour_raw'),@t('RsvLowerLimitProfile'),@t('RsvUpperLimitProfile'))
 ```
@@ -27,7 +29,7 @@ series. If the limit time series have a repetitive frequency, you can use the
 [PROFILE](../functions/profile.md) function to repeat values from a given period and
 resolution.
 
-**Example 2**
+### Example 2
 
 `RsvLowerLimitProfile = @PROFILE(@t('RsvLowerLimit'),'YEAR')`
 
@@ -36,14 +38,14 @@ resolution.
 You can also use a vector of numbers and use the [TIME_MASK](../functions/time_mask.md)
 function to place the values right in time.
 
-Example 3
+### Example 3
 ```
 LowerLimit = @TIME_MASK('YEAR',{'YEAR','YEAR+1m','YEAR+2m','YEAR+3m','YEAR+4m','YEAR+5m','YEAR+6m','YEAR+7m','YEAR+8m','YEAR+9m','YEAR+10m','YEAR+11m'},@D('RsvLowerLimitMonthly'),'VARINT')
 ```
 If the lower and upper limits are constant, you can use the function syntax
 @ValidateAbsLimit(t,d,d).
 
-Example 4
+### Example 4
 
 `Waterlevel_hour_VEE = @ValidateAbsLimit(@RESET_STATUS(@t('Waterlevel_hour_raw')),207,210)`
 

--- a/docs/mesh/calculations/functions/validate_delta_limit.md
+++ b/docs/mesh/calculations/functions/validate_delta_limit.md
@@ -1,12 +1,12 @@
-﻿## ValidateDeltaLimit
-**About the function**
+﻿# ValidateDeltaLimit
+## About the function
 
 Validates time series using delta change limits. Values outside the specified
 limits, will be marked as ! (Not OK). Values with control towards delta limit
 are set to validated with remark V02, meaning validation method 2. You can see
 this code if you turn on value information in Nimbus.
 
-**Syntax**
+## Syntax
 
 - ValidateDeltaLimit(t,t,t,d,s)
 
@@ -20,7 +20,7 @@ this code if you turn on value information in Nimbus.
 | 4 | d | Value describing maximum number of errors. When maximum number of errors has been reached, subsequent values will not be validated. |
 | 5 | s | Symbol describing whether or not limitation time series are to be interpreted as percentage values. This is specified as either 'TRUE' or 'FALSE'. |
 
-**Example**
+## Example
 ```
 Waterlevel_hour_VEE = @ValidateDeltaLimit(@RESET_STATUS(@t('Waterlevel_hour_raw')),@TS('VARINT',@d('RsvDeltaLimitLower')),@TS('VARINT',@d('RsvDeltaLimitUpper')),
 @d('ValidateMaxErrors'), @s('ValuesInPercent'))

--- a/docs/mesh/calculations/functions/validate_delta_limit_extreme.md
+++ b/docs/mesh/calculations/functions/validate_delta_limit_extreme.md
@@ -1,5 +1,5 @@
-﻿## ValidateDeltaLimitExtreme
-**About the function**
+﻿# ValidateDeltaLimitExtreme
+## About the function
 
 ValidateDeltaLimitExtreme is similar to
 [ValidateDeltaLimit](../functions/validate_delta_limit.md), but also validates using

--- a/docs/mesh/calculations/functions/validate_repeat_value.md
+++ b/docs/mesh/calculations/functions/validate_repeat_value.md
@@ -1,12 +1,12 @@
-﻿## ValidateRepeatValue
-**About the function**
+﻿# ValidateRepeatValue
+## About the function
 
 This function validates time series based on repetition frequency. Values
 repeated too often, are marked with **!** (Not OK). Values with control towards
 repeated values are set to validated and marked with **V04**, meaning validation
 method 4. You can see this code if you turn on value information in Nimbus.
 
-**Syntax**
+## Syntax
 
 - ValidateRepeatValue(t,t,d,d)
 

--- a/docs/mesh/calculations/functions/values_from_year.md
+++ b/docs/mesh/calculations/functions/values_from_year.md
@@ -1,4 +1,4 @@
-﻿# **ValuesFromYear**
+﻿# ValuesFromYear
 ## About the function
 Gets values from a specified year on input series and places them into the
 requested period.
@@ -13,6 +13,6 @@ requested period.
 | 1 | t | Source time series. |   |
 | 2 | d | Year as a four digit number. Standard DB calendar is used to map year number into time period. | 2000 |
 
-**Example**
+## Example
 
 `CompareTemp = @ValuesFromYear(@t('AreaTemperature'),2000)`

--- a/docs/mesh/calculations/functions/zxy.md
+++ b/docs/mesh/calculations/functions/zxy.md
@@ -1,5 +1,5 @@
 # ZX_Y
-  **About the function**
+## About the function
 
 Gets the result Y from an XYZ-attribute with input series Z and X. An
 XYZ-attribute is a table in three dimensions defined on a Mesh object, e.g. a


### PR DESCRIPTION
* One H1 title per page
* "About the function"/Syntax/Description/Examples at H2
* Convert bold/plain-text pseudo-headers to real headers
* Standardize multi-variant pages (variant at H2, sections at H3)
* Add missing "About the function" sections
* Fix stray header markup in tables and example headers - e.g. docs/mesh/calculations/functions/get_ts_audit_times.md