### PR TITLE
`CorrectAverageValue` Mesh calc function improvements

### DIFF
--- a/docs/mesh/calculations/functions/correct_average_value.md
+++ b/docs/mesh/calculations/functions/correct_average_value.md
@@ -8,10 +8,9 @@ code if you turn on value information in Nimbus.
 ## Syntax
 
 - CorrectAverageValue(t,d,s,s,d,T,D,S)
+- CorrectAverageValue(t,d,s,s,d,T,D,D,D,S)
 
 ## Description
-
-CorrectAverageValue(t,d,s,s,d,T,D,D,D,S)
 
 | # | Type | Description |
 |---|---|---|
@@ -21,12 +20,10 @@ CorrectAverageValue(t,d,s,s,d,T,D,D,D,S)
 | 4 | s | Symbol describing whether or not time series are accumulated time series. This is specified as 'TRUE' or 'FALSE'. |
 | 5 | d | Value giving the limit for right endpoint adaptation. This value has no effect unless time series are accumulated time series. Limit for right attachment specifies threshold value for right end point attachment. E.g if the difference between previous OK value and next OK value is less than this value, right end point will not be attached which means a standard method operation is performed. |
 | 6 | T | An array of time series to be used in the correction. |
-| 7 | D | An array of weight values. Weighting is used if you want values from a particular series to have a greater effect on the average than other series. Each value included in the average value calculation is multiplied by its respective weighting before it is added to an accumulated value. You get the final value by dividing the accumulated value by the sum of the weighting for the series included in the average value calculation. |
-| 8 | D | An array with symbols describing whether or not corrected values can be used. This is specified as 'TRUE' or 'FALSE'. |
-
-If you want to use a scale factor or an offset factor before combining the time
-series into the result time series, you can define these as attributes on the
-specific object and use them in the calculation of the input time series.
+| 7 | D | An array of weight values. Weighting is used if you want values from a particular series to have a greater effect on the average than other series. Each value included in the average value calculation is multiplied by its respective weighting before it is added to an accumulated value. You get the final value by dividing the accumulated value by the sum of the weighting for the series included in the average value calculation. If the array is empty, all weights default to 1.0. |
+| 8 | D | Only in the 10-argument variant. An array of scale factors, one per time series in argument 6. Each contribution value is multiplied by its scale factor before it enters the average value calculation. In the 8-argument variant all scale factors are 1.0. |
+| 9 | D | Only in the 10-argument variant. An array of offset values, one per time series in argument 6. The offset is added to the contribution value after scaling, i.e. each contribution is calculated as scale factor * value + offset. In the 8-argument variant all offsets are 0.0. |
+| 10 | S | An array with symbols describing whether or not corrected values can be used. This is specified as 'TRUE' or 'FALSE'. This is always the last argument, i.e. argument 8 in the 8-argument variant. If the array is empty, all values default to 'TRUE'. |
 
 **Note!** To avoid circular references in the calculation of the correction
 values using the method average value, the input time series used in the


### PR DESCRIPTION
* Add description of arguments for the 10-argument variant
* Add more info about last argument: array of strings `S`
* Add more info about weight values argument.
* Remove the part with defining scale and offset factors as attributes - we have the 10-argument variant for that.