### PR TITLE
docs(mdt): document AMQPmessageTypes v1.2 namespace and audit fields

### DIFF
--- a/docs/mesh-data-transfer/general/general.md
+++ b/docs/mesh-data-transfer/general/general.md
@@ -29,7 +29,7 @@ The reply message uses the same namespace as the request it answers. If you send
 
 ### Namespace used on export
 
-For the Standard export protocol, the namespace of the exported message is controlled by the `Storage:StoragePerProtocol:StdExport:SchemaVersion` configuration setting. The accepted values are `1.0` (the default) and `1.1`, so exported messages carry `.../v1.0` or `.../v1.1` — not `.../v1.2`. This is why the examples in [Export of time series values](../use-cases/export-of-time-series-values-using-mdt.md) show a `v1.0` namespace while the import examples show `v1.2`.
+For the **Standard** export protocol, the namespace of the exported message is controlled by the `Storage:StoragePerProtocol:StdExport:SchemaVersion` configuration setting. The accepted values are `1.0` (the default) and `1.1`, so exported messages carry `.../v1.0` or `.../v1.1`, not `.../v1.2`. This is why the examples in [Export of time series values](../use-cases/export-of-time-series-values-using-mdt.md) show a `v1.0` namespace while the import examples show `v1.2`.
 
 Apart from the version in the namespace URI, and the optional fields added in later versions, the message structure is unchanged across these versions.
 

--- a/docs/mesh-data-transfer/general/general.md
+++ b/docs/mesh-data-transfer/general/general.md
@@ -4,6 +4,35 @@ The _Mesh Data Transfer_ service enables users to perform time series and availa
 
 Mesh Data Transfer offers HTTP endpoints for creating both availability and time series export orders (used by certain Volue products, e.g. Participant, Nimbus). Imports are requested via queues (AMQP 1.0 or Azure Service Bus) and the outcomes of the import operations are sent to AMQP reply queues. The export results are stored as files or sent to an AMQP queue, depending on the configuration. Mesh Data Transfer is also responsible for saving export status to the `Message Log` (in the case of imports it is done by Mesh).
 
+## XML schema and namespaces
+
+The XML message formats used by Mesh Data Transfer are defined by [`AMQPmessageTypes.xsd`](../use-cases/xsd/AMQPmessageTypes.xsd). The schema version is part of the XML namespace, which is why the namespace URI ends in a version number. The current schema version is **v1.2**:
+
+```
+http://www.powel.com/SmE/AMQPmessageTypes/v1.2
+```
+
+### Namespaces accepted on import
+
+Mesh Data Transfer accepts all of the following namespaces on incoming import messages and treats them as equivalent:
+
+| Namespace | Status |
+| --- | --- |
+| `http://www.powel.com/SmE/AMQPmessageTypes` | Legacy, unversioned. Still accepted. |
+| `http://www.powel.com/SmE/AMQPmessageTypes/v1.0` | Still accepted. |
+| `http://www.powel.com/SmE/AMQPmessageTypes/v1.1` | Still accepted. |
+| `http://www.powel.com/SmE/AMQPmessageTypes/v1.2` | Current. Use this for new integrations. |
+
+Existing integrations do not need to change their namespace. However, only the v1.2 schema describes the most recently added fields — for example the `CreatedBy`, `LastChangedBy` and `CreatedTime` attributes on availability events — so validate against v1.2 if you want to use them.
+
+The reply message uses the same namespace as the request it answers. If you send a request in the unversioned namespace, the reply is returned in the unversioned namespace.
+
+### Namespace used on export
+
+For the Standard export protocol, the namespace of the exported message is controlled by the `Storage:StoragePerProtocol:StdExport:SchemaVersion` configuration setting. The accepted values are `1.0` (the default) and `1.1`, so exported messages carry `.../v1.0` or `.../v1.1` — not `.../v1.2`. This is why the examples in [Export of time series values](../use-cases/export-of-time-series-values-using-mdt.md) show a `v1.0` namespace while the import examples show `v1.2`.
+
+Apart from the version in the namespace URI, and the optional fields added in later versions, the message structure is unchanged across these versions.
+
 ## Usage
 
 ### API Documentation (Swagger)

--- a/docs/mesh-data-transfer/use-cases/export-of-time-series-values-using-mdt.md
+++ b/docs/mesh-data-transfer/use-cases/export-of-time-series-values-using-mdt.md
@@ -2,7 +2,10 @@
 
 This document describes how time series values can be exported from Mesh using Mesh Data Transfer and AMQP messages in the Mesh standard XML format.
 
-The definition of the XML format is found in the [`AMQPmessageTypes.xsd`](./xsd/AMQPmessageTypes.xsd).
+The definition of the XML format is found in the [`AMQPmessageTypes.xsd`](./xsd/AMQPmessageTypes.xsd), which describes the current
+schema version, v1.2. The examples below show a `v1.0` namespace because the namespace of an exported message is set by the
+`Storage:StoragePerProtocol:StdExport:SchemaVersion` configuration setting, which accepts `1.0` (the default) or `1.1`. See
+[XML schema and namespaces](../general/general.md#xml-schema-and-namespaces).
 
 Currently, when doing exports, it it necessary to define export definitions in the SmG Participant application using transfer definitions defined using the SmG Import/Export application.
 

--- a/docs/mesh-data-transfer/use-cases/import-of-availability-events-using-mdt.md
+++ b/docs/mesh-data-transfer/use-cases/import-of-availability-events-using-mdt.md
@@ -4,7 +4,7 @@ This document describes how availability events can be imported into Mesh using 
 Mesh standard XML format.
 
 The definition of the XML format is found in the [`AMQPmessageTypes.xsd`](./xsd/AMQPmessageTypes.xsd). The examples below use the
-current schema namespace, `http://www.powel.com/SmE/AMQPmessageTypes/v1.2`. Older namespaces are still accepted — see
+current schema namespace, `http://www.powel.com/SmE/AMQPmessageTypes/v1.2`. Older namespaces are still accepted, see
 [XML schema and namespaces](../general/general.md#xml-schema-and-namespaces).
 
 - [Import of availability events using Mesh Data Transfer](#import-of-availability-events-using-mesh-data-transfer)

--- a/docs/mesh-data-transfer/use-cases/import-of-availability-events-using-mdt.md
+++ b/docs/mesh-data-transfer/use-cases/import-of-availability-events-using-mdt.md
@@ -3,6 +3,10 @@
 This document describes how availability events can be imported into Mesh using Mesh Data Transfer and AMQP messages in the
 Mesh standard XML format.
 
+The definition of the XML format is found in the [`AMQPmessageTypes.xsd`](./xsd/AMQPmessageTypes.xsd). The examples below use the
+current schema namespace, `http://www.powel.com/SmE/AMQPmessageTypes/v1.2`. Older namespaces are still accepted — see
+[XML schema and namespaces](../general/general.md#xml-schema-and-namespaces).
+
 - [Import of availability events using Mesh Data Transfer](#import-of-availability-events-using-mesh-data-transfer)
   - [Different event types handled](#different-event-types-handled)
   - [Different message types](#different-message-types)
@@ -50,7 +54,7 @@ This is an example of the structure of the XML message:
 <?xml version="1.0" encoding="utf-8"?>
 <Request xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-xmlns="http://www.powel.com/SmE/AMQPmessageTypes">
+xmlns="http://www.powel.com/SmE/AMQPmessageTypes/v1.2">
   <MessageId>12345678-1234-1234-1234-123456789012</MessageId>
   <MessageVersion>1.0.0.0</MessageVersion>
   <ForceAvailabilityEventCreation>true</ForceAvailabilityEventCreation>
@@ -97,6 +101,10 @@ successful. The found object is the object where the events are created below.
 - `EventId` - this is a text string that identifies the created event. This id is normally created within the
 external system that "owns" the event. When updating and delete an event, object and event id must
 match.
+- `CreatedBy` - (optional) text string that identifies the user or system that created the event. This field is stored in
+Mesh and can be used for auditing purposes.
+- `LastChangedBy` - (optional) text string that identifies the user or system that last changed the event.
+- `CreatedTime` - (optional) timestamp when the event was originally created.
 - `SubEvent/Status` - text string that identifies the status of the event. Legal values for revision events
 are:
   - `Proposed` - suggestion from Maintenance Planner.
@@ -158,6 +166,10 @@ values are:
   - `Priority`
   - `ReservoirTacticalLevelMax [m]`
   - `ReservoirTacticalLevelMin [m]`
+- `CreatedBy` - (optional) text string that identifies the user or system that created the event. This field is stored in
+Mesh and can be used for auditing purposes.
+- `LastChangedBy` - (optional) text string that identifies the user or system that last changed the event.
+- `CreatedTime` - (optional) timestamp when the event was originally created.
 - `SubEvent/Status` - text string that identifies the status of the event. Legal values for restriction events
 are:
   - `SelfImposed` - restriction is due to internal needs.
@@ -190,7 +202,7 @@ match.
 <?xml version="1.0" encoding="utf-8"?>
 <Reply xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-xmlns="http://www.powel.com/SmE/AMQPmessageTypes">
+xmlns="http://www.powel.com/SmE/AMQPmessageTypes/v1.2">
   <RequestMessageId>12345678-1234-1234-1234-123456789012</RequestMessageId>
   <MessageVersion>1.0.0.0</MessageVersion>
   <ImportSuccess>false</ImportSuccess>
@@ -213,7 +225,7 @@ Parameters:
 <?xml version="1.0" encoding="utf-8"?>
 <Request xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-xmlns="http://www.powel.com/SmE/AMQPmessageTypes">
+xmlns="http://www.powel.com/SmE/AMQPmessageTypes/v1.2">
   <MessageId>12345678-1234-1234-1234-123456789012</MessageId>
   <MessageVersion>1.0.0.0</MessageVersion>
   <ForceAvailabilityEventCreation>true</ForceAvailabilityEventCreation>
@@ -223,7 +235,8 @@ xmlns="http://www.powel.com/SmE/AMQPmessageTypes">
   <Inputs>
     <AvailabilityEvents>
       <RevisionEvent Path="Mode/Company/Mesh" Search="*
-[.Type=Generator&amp;&amp;.Name=ADKOL.856]" EventId="1234">
+[.Type=Generator&amp;&amp;.Name=ADKOL.856]" EventId="1234"
+CreatedBy="Mesh Data Transfer" CreatedTime="2021-01-01T00:00:00Z">
         <SubEvent Status="Planned" Description="" Value="1">
           <Frequency Start="2022-04-06T06:00:00Z" End="2022-04-06T10:00:00Z" />
         </SubEvent>
@@ -239,7 +252,7 @@ xmlns="http://www.powel.com/SmE/AMQPmessageTypes">
 <?xml version="1.0" encoding="utf-8"?>
 <Request xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-xmlns="http://www.powel.com/SmE/AMQPmessageTypes">
+xmlns="http://www.powel.com/SmE/AMQPmessageTypes/v1.2">
   <MessageId>12345678-1234-1234-1234-123456789013</MessageId>
   <MessageVersion>1.0.0.0</MessageVersion>
   <ForceAvailabilityEventCreation>true</ForceAvailabilityEventCreation>
@@ -266,7 +279,7 @@ Value="1">
 <?xml version="1.0" encoding="utf-8"?>
 <Request xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-xmlns="http://www.powel.com/SmE/AMQPmessageTypes">
+xmlns="http://www.powel.com/SmE/AMQPmessageTypes/v1.2">
   <MessageId>12345678-1234-1234-1234-123456789014</MessageId>
   <MessageVersion>1.0.0.0</MessageVersion>
   <ForceAvailabilityEventCreation>true</ForceAvailabilityEventCreation>
@@ -288,7 +301,7 @@ xmlns="http://www.powel.com/SmE/AMQPmessageTypes">
 <?xml version="1.0" encoding="utf-8"?>
 <Request xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-xmlns="http://www.powel.com/SmE/AMQPmessageTypes">
+xmlns="http://www.powel.com/SmE/AMQPmessageTypes/v1.2">
   <MessageId>12345678-1234-1234-1234-123456789015</MessageId>
   <MessageVersion>1.0.0.0</MessageVersion>
   <ForceAvailabilityEventCreation>true</ForceAvailabilityEventCreation>
@@ -299,7 +312,8 @@ xmlns="http://www.powel.com/SmE/AMQPmessageTypes">
     <AvailabilityEvents>
       <RestrictionEvent Path="Mode/Company/Mesh" Search="*
 [.Type=Generator&amp;&amp;.Name=ADKOL.856]" EventId="2345"
-Category="PowerUnavailable[MW]">
+Category="PowerUnavailable[MW]" CreatedBy="Mesh Data Transfer"
+CreatedTime="2021-02-01T00:00:00Z">
         <SubEvent Status="SelfImposed" Description="" Value="-1">
           <Frequency Start="2022-04-06T06:00:00Z" End="2022-04-06T10:00:00Z" />
         </SubEvent>
@@ -315,7 +329,7 @@ Category="PowerUnavailable[MW]">
 <?xml version="1.0" encoding="utf-8"?>
 <Request xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-xmlns="http://www.powel.com/SmE/AMQPmessageTypes">
+xmlns="http://www.powel.com/SmE/AMQPmessageTypes/v1.2">
   <MessageId>12345678-1234-1234-1234-123456789016</MessageId>
   <MessageVersion>1.0.0.0</MessageVersion>
   <ForceAvailabilityEventCreation>true</ForceAvailabilityEventCreation>
@@ -342,7 +356,7 @@ Category="PowerUnavailable[MW]">
 <?xml version="1.0" encoding="utf-8"?>
 <Request xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-xmlns="http://www.powel.com/SmE/AMQPmessageTypes">
+xmlns="http://www.powel.com/SmE/AMQPmessageTypes/v1.2">
   <MessageId>12345678-1234-1234-1234-123456789017</MessageId>
   <MessageVersion>1.0.0.0</MessageVersion>
   <ForceAvailabilityEventCreation>true</ForceAvailabilityEventCreation>
@@ -364,7 +378,7 @@ xmlns="http://www.powel.com/SmE/AMQPmessageTypes">
 <?xml version="1.0" encoding="utf-8"?>
 <Reply xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-xmlns="http://www.powel.com/SmE/AMQPmessageTypes">
+xmlns="http://www.powel.com/SmE/AMQPmessageTypes/v1.2">
   <RequestMessageId>12345678-1234-1234-1234-123456789012</RequestMessageId>
   <MessageVersion>1.0.0.0</MessageVersion>
   <ImportSuccess>true</ImportSuccess>
@@ -377,7 +391,7 @@ xmlns="http://www.powel.com/SmE/AMQPmessageTypes">
 <?xml version="1.0" encoding="utf-8"?>
 <Reply xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-xmlns="http://www.powel.com/SmE/AMQPmessageTypes">
+xmlns="http://www.powel.com/SmE/AMQPmessageTypes/v1.2">
   <RequestMessageId>12345678-1234-1234-1234-123456789012</RequestMessageId>
   <MessageVersion>1.0.0.0</MessageVersion>
   <ImportSuccess>false</ImportSuccess>

--- a/docs/mesh-data-transfer/use-cases/import-of-time-series-values-using-mdt.md
+++ b/docs/mesh-data-transfer/use-cases/import-of-time-series-values-using-mdt.md
@@ -4,7 +4,7 @@ This document describes how time series values can be imported into Mesh using M
 Mesh standard XML format.
 
 The definition of the XML format is found in the [`AMQPmessageTypes.xsd`](./xsd/AMQPmessageTypes.xsd). The examples below use the
-current schema namespace, `http://www.powel.com/SmE/AMQPmessageTypes/v1.2`. Older namespaces are still accepted — see
+current schema namespace, `http://www.powel.com/SmE/AMQPmessageTypes/v1.2`. Older namespaces are still accepted, see
 [XML schema and namespaces](../general/general.md#xml-schema-and-namespaces).
 
 - [Import of time series values using Mesh Data Transfer](#import-of-time-series-values-using-mesh-data-transfer)

--- a/docs/mesh-data-transfer/use-cases/import-of-time-series-values-using-mdt.md
+++ b/docs/mesh-data-transfer/use-cases/import-of-time-series-values-using-mdt.md
@@ -3,7 +3,9 @@
 This document describes how time series values can be imported into Mesh using Mesh Data Transfer and AMQP messages in the
 Mesh standard XML format.
 
-The definition of the XML format is found in the [`AMQPmessageTypes.xsd`](./xsd/AMQPmessageTypes.xsd).
+The definition of the XML format is found in the [`AMQPmessageTypes.xsd`](./xsd/AMQPmessageTypes.xsd). The examples below use the
+current schema namespace, `http://www.powel.com/SmE/AMQPmessageTypes/v1.2`. Older namespaces are still accepted — see
+[XML schema and namespaces](../general/general.md#xml-schema-and-namespaces).
 
 - [Import of time series values using Mesh Data Transfer](#import-of-time-series-values-using-mesh-data-transfer)
   - [XML input message structure](#xml-input-message-structure)
@@ -24,7 +26,7 @@ This is an example of the structure of the XML message:
 <?xml version="1.0" encoding="utf-8"?>
 <Request xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-xmlns="http://www.powel.com/SmE/AMQPmessageTypes">
+xmlns="http://www.powel.com/SmE/AMQPmessageTypes/v1.2">
   <MessageId>12345678-1234-1234-1234-123456789012</MessageId>
   <MessageVersion>1.0.0.0</MessageVersion>
   <Sender>SenderName</Sender>
@@ -96,7 +98,7 @@ Other conventions:
 <?xml version="1.0" encoding="utf-8"?>
 <Reply xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-xmlns="http://www.powel.com/SmE/AMQPmessageTypes">
+xmlns="http://www.powel.com/SmE/AMQPmessageTypes/v1.2">
   <RequestMessageId>12345678-1234-1234-1234-123456789012</RequestMessageId>
   <MessageVersion>1.0.0.0</MessageVersion>
   <ImportSuccess>false</ImportSuccess>
@@ -123,7 +125,7 @@ When a message is successfully received and translated by Mesh Data Transfer, it
 
 ````xml
 <?xml version="1.0" encoding="utf-8"?>
-<Request xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.powel.com/SmE/AMQPmessageTypes">
+<Request xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.powel.com/SmE/AMQPmessageTypes/v1.2">
   <MessageId>12345678-1234-1234-1234-123456789012</MessageId>
   <MessageVersion>1.0.0.0</MessageVersion>
   <Sender>SenderName</Sender>
@@ -448,7 +450,7 @@ When a message is successfully received and translated by Mesh Data Transfer, it
 <?xml version="1.0" encoding="utf-8"?>
 <Reply xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-xmlns="http://www.powel.com/SmE/AMQPmessageTypes">
+xmlns="http://www.powel.com/SmE/AMQPmessageTypes/v1.2">
   <RequestMessageId>12345678-1234-1234-1234-123456789012</RequestMessageId>
   <MessageVersion>1.0.0.0</MessageVersion>
   <ImportSuccess>true</ImportSuccess>
@@ -461,7 +463,7 @@ xmlns="http://www.powel.com/SmE/AMQPmessageTypes">
 <?xml version="1.0" encoding="utf-8"?>
 <Reply xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-xmlns="http://www.powel.com/SmE/AMQPmessageTypes">
+xmlns="http://www.powel.com/SmE/AMQPmessageTypes/v1.2">
   <RequestMessageId>12345678-1234-1234-1234-123456789012</RequestMessageId>
   <MessageVersion>1.0.0.0</MessageVersion>
   <ImportSuccess>false</ImportSuccess>


### PR DESCRIPTION
The published MDT docs still described schema v1.1 in prose, while the XSD was updated to v1.2 (commit 1ef74aa). Two gaps remained:

- The `CreatedBy`, `LastChangedBy` and `CreatedTime` attributes added to `RestrictionEvent` and `RevisionEvent` in v1.2 were never documented (energy-mesh-data-transfer#801).
- The import examples used the legacy unversioned namespace and the export examples used v1.0, while both docs link the v1.2 schema. Three different namespaces, one schema file, no explanation.

Changes:

- Add an "XML schema and namespaces" section to general.md stating which namespaces are accepted on import, that the reply echoes the request namespace, and that the export namespace follows the StdExport SchemaVersion setting.
- Document the three audit attributes on both RevisionEvent and RestrictionEvent, and show them in the create examples.
- Move the import examples to the current v1.2 namespace and explain why the export examples stay on v1.0.